### PR TITLE
Allow LLP officers to be returned for Emergency Auth Code requests

### DIFF
--- a/src/main/java/uk/gov/ch/repository/officers/EmergencyAuthCodeEligibleOfficersRepository.java
+++ b/src/main/java/uk/gov/ch/repository/officers/EmergencyAuthCodeEligibleOfficersRepository.java
@@ -14,7 +14,7 @@ public interface EmergencyAuthCodeEligibleOfficersRepository extends PagingAndSo
             "and cb.CORPORATE_BODY_ID = cba.CORPORATE_BODY_ID " +
             "and cba.OFFICER_ID = od.OFFICER_ID " +
             "and cba.OFFICER_ID = o.OFFICER_ID " +
-            "and cba.APPOINTMENT_TYPE_ID = 2 " +
+            "and cba.APPOINTMENT_TYPE_ID IN (2, 3, 4) " +
             "and cba.RESIGNATION_IND = 'N' " +
             "and od.OFFICER_DISQUALIFICATION_IND = 'N' " +
             "and o.CORPORATE_OFFICER_IND = 'N'",
@@ -28,7 +28,7 @@ public interface EmergencyAuthCodeEligibleOfficersRepository extends PagingAndSo
             "and cb.CORPORATE_BODY_ID = cba.CORPORATE_BODY_ID " +
             "and cba.OFFICER_ID = od.OFFICER_ID " +
             "and cba.OFFICER_ID = o.OFFICER_ID " +
-            "and cba.APPOINTMENT_TYPE_ID = 2 " +
+            "and cba.APPOINTMENT_TYPE_ID IN (2, 3, 4) " +
             "and cba.RESIGNATION_IND = 'N' " +
             "and od.OFFICER_DISQUALIFICATION_IND = 'N' " +
             "and o.CORPORATE_OFFICER_IND = 'N' " +

--- a/src/test/java/uk/gov/ch/service/emergencyauthcode/impl/EmergencyOfficersServiceImplTest.java
+++ b/src/test/java/uk/gov/ch/service/emergencyauthcode/impl/EmergencyOfficersServiceImplTest.java
@@ -47,7 +47,7 @@ public class EmergencyOfficersServiceImplTest {
         CorporateBodyAppointments returnedCorporateBodyAppointments = service.getEligibleOfficersEmergencyAuthCode(INCORPORATION_NUMBER);
         assertEquals(2, returnedCorporateBodyAppointments.getTotalResults());
         assertEquals(0, returnedCorporateBodyAppointments.getStartIndex());
-        assertEquals(2, returnedCorporateBodyAppointments.getItemsPerPage());
+        assertEquals(15, returnedCorporateBodyAppointments.getItemsPerPage());
     }
 
     @Test


### PR DESCRIPTION
Returns officers with appointment types 3 and 4 (LLP's) for officers who can file emergency-auth-codes.

Also fixed broken unit test where items_per_page had been changed.

Resolves: BI-3944