### PR TITLE
Add jib plugin for docker build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,11 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>jib-maven-plugin</artifactId>
+                <version>2.6.0</version>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This plugin will be executed by the concourse pipeline to build a docker image to push to our ecr