### PR TITLE
Add bankrupt officer search endpoint to spec

### DIFF
--- a/specs/OracleQueries.yml
+++ b/specs/OracleQueries.yml
@@ -13,8 +13,6 @@ tags:
     description: current action code set against the company
   - name: scottish-bankrupt-officer-search
     description: search for a Scottish bankrupt officer
-  - name: scottish-bankrupt-officer-details
-    description: view details for a Scottish bankrupt officer
     
 paths:
   /emergency-auth-code/company/{company_number}/eligible-officers:
@@ -111,23 +109,6 @@ paths:
                 $ref: '#/components/schemas/scottishBankruptOfficers'
         '404':
           description: No Scottish bankrupt officers found
-  /officer-search/scottish-bankrupt-officers/{officer_id}:
-    parameters:
-      - $ref: '#/components/parameters/officerId'
-    get:
-      tags:
-        - scottish-bankrupt-officer-details
-      operationId: viewScottishBankruptOfficer
-      summary: View details for a Scottish bankrupt officer
-      responses:
-        '200':
-          description: The details of the Scottish bankrupt officer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/scottishBankruptOfficer'
-        '404':
-          description: Scottish bankrupt officer not found
 components:
   schemas:
     companyOfficer:

--- a/specs/OracleQueries.yml
+++ b/specs/OracleQueries.yml
@@ -95,6 +95,11 @@ paths:
         '404':
           description: Not found
   /officer-search/scottish-bankrupt-officers:
+    parameters:
+      - $ref: '#/components/parameters/forename'
+      - $ref: '#/components/parameters/surname'
+      - $ref: '#/components/parameters/dateOfBirth'
+      - $ref: '#/components/parameters/postcode'
     get:
       tags:
         - scottish-bankrupt-officer-search
@@ -291,7 +296,6 @@ components:
     scottishBankruptOfficer:
       type: object
       required:
-        - id
         - forename1
         - forename2
         - alias
@@ -310,80 +314,64 @@ components:
         - debtor_discharge_date
         - trustee_discharge_date
       properties:
-        id:
-          type: string
-          description: The id of the user
-          readOnly: true
         forename1:
           type: string
-          description: The officers' first name
-          example: 
+          description: The officers' first name.
         forename2:
           type: string
-          description: The officers' other forenames
-          example: 
+          description: The officers' other forenames.
         alias:
           type: string
-          description: The officers' alias/other name
-          example: 
+          description: The officers' alias/other name.
         surname:
           type: string
-          description: The officers' surname
-          example: 
+          description: The officers' surname.
         date_of_birth:
           type: string
-          format: date
-          description: The officers' date of birth details
-          example: 2020-01-01
+          description: The officers' date of birth.
+          example: "2020-01-01"
         address_line_1:
           type: string
-          description: 
-          example: 
+          description: The first line of the address.
         address_line_2:
           type: string
-          description: 
-          example: 
+          description: The second line of the address.
         address_line_3:
           type: string
-          description: 
-          example: 
+          description: The third line of the address.
         town:
           type: string
-          description: 
-          example: 
+          description: The town the bankrupt officer lives in.
         county:
           type: string
-          description: 
-          example: 
+          description: The county the bankrupt officer lives in.
         postcode:
           type: string
-          description: 
-          example: 
+          description: The postcode for the address.
         case_reference: 
           type: string
-          description: 
-          example: 
+          description: Unique ID for the insolvency or trust deed. This could be supplied in any format.
         case_type: 
           type: string
-          description: 
-          example: 
+          enum:
+            - "Insolvency"
+            - "Trust Deed"
+          description: Whether it is an insolvency or trust deed.
         bankruptcy_type: 
           type: string
-          description: 
-          example: 
+          description: The sub-type of insolvency. This will not exist for trust deeds.
         start_date: 
           type: string
-          format: date
-          description: 
-          example: 2020-01-01
-        debtor_dischargeDate: 
+          description: Date which the insolvency/trust deed begins.
+          example: "2020-01-01"
+        debtor_discharge_date: 
           type: string
-          description: 
-          example: 
-        trustee_dischargeDate: 
+          description: Date the restrictions are lifted from the bankrupt officer.
+          example: "2020-01-01"
+        trustee_discharge_date: 
           type: string
-          description: 
-          example: 
+          description: Date the insolvency/trust deed is fully discharged.
+          example: "2020-01-01"
     scottishBankruptOfficers:
       type: object
       required:
@@ -395,19 +383,19 @@ components:
         items_per_page:
           type: integer
           format: int64
-          description: Number of items per page returned in this list
+          description: Number of items per page returned in this list.
           readOnly: true
           example: 10
         start_index:
           type: integer
           format: int64
-          description: The offset into the entire list that this page starts at. Zero indexed
+          description: The offset into the entire list that this page starts at. Zero indexed.
           readOnly: true
           example: 0
         total_results:
           type: integer
           format: int64
-          description: The total number of items in the list
+          description: The total number of items in the list.
           readOnly: true
           example: 0
         items:
@@ -449,3 +437,32 @@ components:
         type: integer
         format: int64
       example: "10"
+    forename:
+      name: 'forename'
+      description: The officers' first name.
+      in: 'query'
+      required: false
+      schema:
+        type: string
+    surname:
+      name: 'surname'
+      description: The officers' surname.
+      in: 'query'
+      required: false
+      schema:
+        type: string
+    dateOfBirth:
+      name: 'dateOfBirth'
+      description: The officers' date of birth.
+      in: 'query'
+      required: false
+      schema:
+        type: string
+      example: "2020-01-01"
+    postcode:
+      name: 'postcode'
+      description: The postcode for the address.
+      in: 'query'
+      required: false
+      schema:
+        type: string

--- a/specs/OracleQueries.yml
+++ b/specs/OracleQueries.yml
@@ -11,6 +11,10 @@ tags:
     description: company efiling status determines whether the company has efiled within a predefined period (e.g 1 calendar month)
   - name: company-action-code
     description: current action code set against the company
+  - name: scottish-bankrupt-officer-search
+    description: search for a Scottish bankrupt officer
+  - name: scottish-bankrupt-officer-details
+    description: view details for a Scottish bankrupt officer
     
 paths:
   /emergency-auth-code/company/{company_number}/eligible-officers:
@@ -92,6 +96,38 @@ paths:
           description: Unauthorised
         '404':
           description: Not found
+  /officer-search/scottish-bankrupt-officers:
+    get:
+      tags:
+        - scottish-bankrupt-officer-search
+      operationId: searchScottishBankruptOfficer
+      summary: Search for a Scottish bankrupt officer
+      responses:
+        '200':
+          description: List of Scottish bankrupt officers.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/scottishBankruptOfficers'
+        '404':
+          description: No Scottish bankrupt officers found
+  /officer-search/scottish-bankrupt-officers/{officer_id}:
+    parameters:
+      - $ref: '#/components/parameters/officerId'
+    get:
+      tags:
+        - scottish-bankrupt-officer-details
+      operationId: viewScottishBankruptOfficer
+      summary: View details for a Scottish bankrupt officer
+      responses:
+        '200':
+          description: The details of the Scottish bankrupt officer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/scottishBankruptOfficer'
+        '404':
+          description: Scottish bankrupt officer not found
 components:
   schemas:
     companyOfficer:
@@ -271,6 +307,132 @@ components:
           description: The current action code for the company
           readOnly: true
           example: 5000
+    scottishBankruptOfficer:
+      type: object
+      required:
+        - id
+        - forename1
+        - forename2
+        - alias
+        - surname
+        - date_of_birth
+        - address_line_1
+        - address_line_2
+        - address_line_3
+        - town
+        - county
+        - postcode
+        - case_reference
+        - case_type
+        - bankruptcy_type
+        - start_date
+        - debtor_discharge_date
+        - trustee_discharge_date
+      properties:
+        id:
+          type: string
+          description: The id of the user
+          readOnly: true
+        forename1:
+          type: string
+          description: The officers' first name
+          example: 
+        forename2:
+          type: string
+          description: The officers' other forenames
+          example: 
+        alias:
+          type: string
+          description: The officers' alias/other name
+          example: 
+        surname:
+          type: string
+          description: The officers' surname
+          example: 
+        date_of_birth:
+          type: string
+          format: date
+          description: The officers' date of birth details
+          example: 2020-01-01
+        address_line_1:
+          type: string
+          description: 
+          example: 
+        address_line_2:
+          type: string
+          description: 
+          example: 
+        address_line_3:
+          type: string
+          description: 
+          example: 
+        town:
+          type: string
+          description: 
+          example: 
+        county:
+          type: string
+          description: 
+          example: 
+        postcode:
+          type: string
+          description: 
+          example: 
+        case_reference: 
+          type: string
+          description: 
+          example: 
+        case_type: 
+          type: string
+          description: 
+          example: 
+        bankruptcy_type: 
+          type: string
+          description: 
+          example: 
+        start_date: 
+          type: string
+          format: date
+          description: 
+          example: 2020-01-01
+        debtor_dischargeDate: 
+          type: string
+          description: 
+          example: 
+        trustee_dischargeDate: 
+          type: string
+          description: 
+          example: 
+    scottishBankruptOfficers:
+      type: object
+      required:
+        - items_per_page
+        - start_index
+        - total_results
+        - items
+      properties:
+        items_per_page:
+          type: integer
+          format: int64
+          description: Number of items per page returned in this list
+          readOnly: true
+          example: 10
+        start_index:
+          type: integer
+          format: int64
+          description: The offset into the entire list that this page starts at. Zero indexed
+          readOnly: true
+          example: 0
+        total_results:
+          type: integer
+          format: int64
+          description: The total number of items in the list
+          readOnly: true
+          example: 0
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/scottishBankruptOfficer'
   parameters:
     companyNumber:
       name: 'company_number'


### PR DESCRIPTION
Add bankrupt officer search endpoint to the spec.

This is a single endpoint which will return all details of each bankrupt officer which matches the search criteria in the query parameters.

Resolves: BI-6428