### PR TITLE
Removing debtor discharge date check from ScottishBankruptOfficersRepository

### DIFF
--- a/src/main/java/uk/gov/ch/repository/officers/ScottishBankruptOfficersRepository.java
+++ b/src/main/java/uk/gov/ch/repository/officers/ScottishBankruptOfficersRepository.java
@@ -34,15 +34,13 @@ public interface ScottishBankruptOfficersRepository extends PagingAndSortingRepo
                  + "where (:forename is null or upper(FORENAME_1) = upper(:forename)) "
                  + "and (:surname is null or upper(SURNAME) = upper(:surname)) "
                  + "and (:dob is null or DATE_OF_BIRTH = TO_DATE(:dob, 'YYYY-MM-DD')) "
-                 + "and (:postcode is null or upper(replace(ADDRESS_POSTCODE, ' ', '')) = upper(replace(:postcode, ' ', ''))) "
-                 + "and trunc(DEBTOR_DISCHARGE_DATE) >= trunc(SYSDATE) ",
+                 + "and (:postcode is null or upper(replace(ADDRESS_POSTCODE, ' ', '')) = upper(replace(:postcode, ' ', ''))) ",
            countQuery = "select COUNT(*) "
                    + "from SCOTTISH_BANKRUPT_OFFICER "
                    + "where (:forename is null or upper(FORENAME_1) = upper(:forename)) "
                    + "and (:surname is null or upper(SURNAME) = upper(:surname)) "
                    + "and (:dob is null or DATE_OF_BIRTH = TO_DATE(:dob, 'YYYY-MM-DD')) "
-                   + "and (:postcode is null or upper(replace(ADDRESS_POSTCODE, ' ', '')) = upper(replace(:postcode, ' ', ''))) "
-                   + "and trunc(DEBTOR_DISCHARGE_DATE) >= trunc(SYSDATE) ",
+                   + "and (:postcode is null or upper(replace(ADDRESS_POSTCODE, ' ', '')) = upper(replace(:postcode, ' ', ''))) ",
            nativeQuery = true)
     Page<ScottishBankruptOfficerDataModel> findScottishBankruptOfficers(@Param("forename") String forename, @Param("surname") String surname, @Param("dob") String dob, @Param("postcode") String postcode, Pageable pageable);
 }


### PR DESCRIPTION
Removing the debtor discharge date check from ScottishBankruptOfficersRepository to return Scottish bankrupt officers regardless of their debtor discharge date.

Resolves: [BI-7045](https://companieshouse.atlassian.net/browse/BI-7045)