### PR TITLE
OBJ-472 adding gaz2 requested endpoint to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Method    | Path                                                                
 **GET**   | `/emergency-auth-code/company/{companyNumber}/eligible-officers/{officerId}` | Calls service to retrieve officer for company number
 **GET**   | `/emergency-auth-code/company/{companyNumber}/efiling-status`                | Calls service to check if company has filed in the past thirty days
 **GET**   | `/company/{companyNumber}/action-code`                                       | Calls service to retrieve the current action code set against the company
+**GET**   | `/company/{companyNumber}/gaz2-requested`                                    | Calls service to check if a gaz2 is requested for the company
 **GET**   | `/officer-search/scottish-bankrupt-officers/{ephemeral_officer_key}`         | Calls service to view the details for a Scottish bankrupt officer
-**POST**   | `/officer-search/scottish-bankrupt-officers`                                | Calls service to search for a Scottish bankrupt officer    
+**POST**  | `/officer-search/scottish-bankrupt-officers`                                 | Calls service to search for a Scottish bankrupt officer    
 
 ### Query parameters
 Query parameter  | Description


### PR DESCRIPTION
Objections added an endpoint to check if a company has had a gaz2 requested on it. This is adding that endpoint description to the oracle-query-api's readme