### PR TITLE
ncs-87 update sql queries to join on shareholding_id.

### DIFF
--- a/src/main/java/uk/gov/ch/dao/ShareholderDao.java
+++ b/src/main/java/uk/gov/ch/dao/ShareholderDao.java
@@ -23,13 +23,13 @@ public class ShareholderDao {
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
-    static final String SHAREHOLDER_COUNT_SQL = "SELECT COUNT(*) FROM shareholder sh INNER JOIN shareholding shd ON sh.shareholder_id = shd.shareholding_id JOIN corporate_body cb on cb.corporate_body_id = shd.corporate_body_id WHERE cb.incorporation_number = ?";
+    static final String SHAREHOLDER_COUNT_SQL = "SELECT COUNT(*) FROM shareholder sh INNER JOIN shareholding shd ON sh.shareholding_id = shd.shareholding_id JOIN corporate_body cb on cb.corporate_body_id = shd.corporate_body_id WHERE cb.incorporation_number = ?";
     
     static final String SHAREHOLDER_ELECTED_COUNT_SQL = "SELECT COUNT(*) FROM shareholder_elected sh JOIN sholdingelc_sholderelc_link shl ON sh.shareholder_elected_id = shl.shareholder_elected_id  INNER JOIN shareholding_elected shd ON shd.shareholding_elected_id = shl.shareholding_elected_id JOIN corporate_body cb on cb.corporate_body_id = shd.corporate_body_id WHERE cb.incorporation_number = ?";
     
     static final String SHAREHOLDER_LIST_SQL = "SELECT sh.shareholder_forename_1 as forename1, sh.shareholder_forename_2 as forename2, sh.shareholder_surname as surname, "
         + "sh.address_id as addressId, shd.number_of_shares as shares, shd.share_class_type_id as shareClassTypeId, shd.currency_type_id as currencyTypeId "
-        + "FROM shareholder sh INNER JOIN shareholding shd ON sh.shareholder_id = shd.shareholding_id "
+        + "FROM shareholder sh INNER JOIN shareholding shd ON sh.shareholding_id = shd.shareholding_id "
         + "JOIN corporate_body cb on cb.corporate_body_id = shd.corporate_body_id WHERE cb.incorporation_number = ?";
 
     static final String SHAREHOLDER_ELECTED_LIST_SQL = "SELECT sh.shareholder_elected_forename_1 as forename1, sh.shareholder_elected_forename_2 as forename2, sh.shareholder_elected_surname as surname, "


### PR DESCRIPTION
Update shareholder/shareholding queries to join on _shareholding_id_ because _shareholder_id_ is not always equal to _shareholding_id_.