### PR TITLE
NCS-87 Moving shareholder files into subfolders to follow the oracle-…

### DIFF
--- a/src/main/java/uk/gov/ch/controller/shareholder/ShareholderController.java
+++ b/src/main/java/uk/gov/ch/controller/shareholder/ShareholderController.java
@@ -1,4 +1,4 @@
-package uk.gov.ch.controller;
+package uk.gov.ch.controller.shareholder;
 
 import java.util.List;
 
@@ -10,8 +10,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import uk.gov.ch.OracleQueryApplication;
-import uk.gov.ch.model.Shareholder;
-import uk.gov.ch.service.ShareholderService;
+import uk.gov.ch.model.shareholder.Shareholder;
+import uk.gov.ch.service.shareholder.ShareholderService;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 

--- a/src/main/java/uk/gov/ch/model/shareholder/Shareholder.java
+++ b/src/main/java/uk/gov/ch/model/shareholder/Shareholder.java
@@ -1,4 +1,4 @@
-package uk.gov.ch.model;
+package uk.gov.ch.model.shareholder;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;

--- a/src/main/java/uk/gov/ch/repository/shareholder/ShareholderRepository.java
+++ b/src/main/java/uk/gov/ch/repository/shareholder/ShareholderRepository.java
@@ -1,4 +1,4 @@
-package uk.gov.ch.dao;
+package uk.gov.ch.repository.shareholder;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -11,12 +11,12 @@ import org.springframework.jdbc.core.PreparedStatementSetter;
 import org.springframework.stereotype.Repository;
 
 import uk.gov.ch.OracleQueryApplication;
-import uk.gov.ch.model.Shareholder;
+import uk.gov.ch.model.shareholder.Shareholder;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
 @Repository
-public class ShareholderDao {
+public class ShareholderRepository {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OracleQueryApplication.APPLICATION_NAME_SPACE);
 

--- a/src/main/java/uk/gov/ch/service/shareholder/ShareholderService.java
+++ b/src/main/java/uk/gov/ch/service/shareholder/ShareholderService.java
@@ -1,7 +1,7 @@
-package uk.gov.ch.service;
+package uk.gov.ch.service.shareholder;
 import java.util.List;
 
-import uk.gov.ch.model.Shareholder;
+import uk.gov.ch.model.shareholder.Shareholder;
 
 public interface ShareholderService {
 

--- a/src/main/java/uk/gov/ch/service/shareholder/impl/ShareholderServiceImpl.java
+++ b/src/main/java/uk/gov/ch/service/shareholder/impl/ShareholderServiceImpl.java
@@ -1,28 +1,28 @@
-package uk.gov.ch.service.impl;
+package uk.gov.ch.service.shareholder.impl;
 
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import uk.gov.ch.dao.ShareholderDao;
-import uk.gov.ch.model.Shareholder;
-import uk.gov.ch.service.ShareholderService;
+import uk.gov.ch.repository.shareholder.ShareholderRepository;
+import uk.gov.ch.model.shareholder.Shareholder;
+import uk.gov.ch.service.shareholder.ShareholderService;
 
 @Service
 public class ShareholderServiceImpl implements ShareholderService {
 
     @Autowired
-    private ShareholderDao shareholderDao;
+    private ShareholderRepository shareholderRepository;
 
     @Override
     public int getShareholderCount(String incorporationNumber) {  
-        return shareholderDao.getShareholderCount(incorporationNumber);
+        return shareholderRepository.getShareholderCount(incorporationNumber);
     }
 
     @Override
     public List<Shareholder> getShareholders(String incorporationNumber) {  
-        return shareholderDao.getShareholders(incorporationNumber);
+        return shareholderRepository.getShareholders(incorporationNumber);
     }
     
 }

--- a/src/test/java/uk/gov/ch/controller/ShareholderControllerTest.java
+++ b/src/test/java/uk/gov/ch/controller/ShareholderControllerTest.java
@@ -15,8 +15,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import uk.gov.ch.model.Shareholder;
-import uk.gov.ch.service.ShareholderService;
+import uk.gov.ch.controller.shareholder.ShareholderController;
+import uk.gov.ch.model.shareholder.Shareholder;
+import uk.gov.ch.service.shareholder.ShareholderService;
 
 @ExtendWith(MockitoExtension.class)
 class ShareholderControllerTest {

--- a/src/test/java/uk/gov/ch/repository/shareholder/ShareholderRepositoryTest.java
+++ b/src/test/java/uk/gov/ch/repository/shareholder/ShareholderRepositoryTest.java
@@ -1,4 +1,4 @@
-package uk.gov.ch.dao;
+package uk.gov.ch.repository.shareholder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -21,16 +21,16 @@ import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.PreparedStatementSetter;
 
-import uk.gov.ch.model.Shareholder;
+import uk.gov.ch.model.shareholder.Shareholder;
 
 @ExtendWith(MockitoExtension.class)
-class ShareholderDaoTest {
+class ShareholderRepositoryTest {
 
     @Mock
     private JdbcTemplate jdbcTemplate;
 
     @InjectMocks
-    private ShareholderDao dao;
+    private ShareholderRepository shareholderRepository;
 
     private static final String COMPANY_NUMBER = "12345678";
 
@@ -40,11 +40,11 @@ class ShareholderDaoTest {
         List<Shareholder> expectedList = new ArrayList<Shareholder>();
         expectedList.add(new Shareholder());
 
-        when(jdbcTemplate.query(eq(ShareholderDao.SHAREHOLDER_LIST_SQL), any(PreparedStatementSetter.class), any(BeanPropertyRowMapper.class))).thenReturn(expectedList);
+        when(jdbcTemplate.query(eq(ShareholderRepository.SHAREHOLDER_LIST_SQL), any(PreparedStatementSetter.class), any(BeanPropertyRowMapper.class))).thenReturn(expectedList);
 
-        List<Shareholder> resultList = dao.getShareholders(COMPANY_NUMBER);
+        List<Shareholder> resultList = shareholderRepository.getShareholders(COMPANY_NUMBER);
 
-        verify(jdbcTemplate, times(0)).query(eq(ShareholderDao.SHAREHOLDER_ELECTED_LIST_SQL), any(PreparedStatementSetter.class), any(BeanPropertyRowMapper.class));
+        verify(jdbcTemplate, times(0)).query(eq(ShareholderRepository.SHAREHOLDER_ELECTED_LIST_SQL), any(PreparedStatementSetter.class), any(BeanPropertyRowMapper.class));
 
         assertEquals(expectedList, resultList);
         assertEquals(1, resultList.size());
@@ -57,11 +57,11 @@ class ShareholderDaoTest {
         List<Shareholder> expectedList = new ArrayList<Shareholder>();
         expectedList.add(new Shareholder());
 
-        when(jdbcTemplate.query(eq(ShareholderDao.SHAREHOLDER_LIST_SQL), any(PreparedStatementSetter.class), any(BeanPropertyRowMapper.class))).thenReturn(new ArrayList<Shareholder>());
+        when(jdbcTemplate.query(eq(ShareholderRepository.SHAREHOLDER_LIST_SQL), any(PreparedStatementSetter.class), any(BeanPropertyRowMapper.class))).thenReturn(new ArrayList<Shareholder>());
 
-        when(jdbcTemplate.query(eq(ShareholderDao.SHAREHOLDER_ELECTED_LIST_SQL), any(PreparedStatementSetter.class), any(BeanPropertyRowMapper.class))).thenReturn(expectedList);
+        when(jdbcTemplate.query(eq(ShareholderRepository.SHAREHOLDER_ELECTED_LIST_SQL), any(PreparedStatementSetter.class), any(BeanPropertyRowMapper.class))).thenReturn(expectedList);
 
-        List<Shareholder> resultList = dao.getShareholders(COMPANY_NUMBER);
+        List<Shareholder> resultList = shareholderRepository.getShareholders(COMPANY_NUMBER);
 
         assertEquals(expectedList, resultList);
         assertEquals(1, resultList.size());
@@ -74,7 +74,7 @@ class ShareholderDaoTest {
 
         when(jdbcTemplate.query(anyString(), any(PreparedStatementSetter.class), any(BeanPropertyRowMapper.class))).thenReturn(expectedList);
 
-        List<Shareholder> resultList = dao.getShareholders(COMPANY_NUMBER);
+        List<Shareholder> resultList = shareholderRepository.getShareholders(COMPANY_NUMBER);
 
         assertEquals(expectedList, resultList);
         assertEquals(0, resultList.size());
@@ -83,10 +83,10 @@ class ShareholderDaoTest {
     @Test
     @DisplayName("Get shareholders count - company with shareholders")
     void getShareholderCountFromShareholdersTableTest() {
-        when(jdbcTemplate.queryForObject(eq(ShareholderDao.SHAREHOLDER_COUNT_SQL), eq(Integer.class),
+        when(jdbcTemplate.queryForObject(eq(ShareholderRepository.SHAREHOLDER_COUNT_SQL), eq(Integer.class),
                 eq(COMPANY_NUMBER))).thenReturn(1);
 
-        int result = dao.getShareholderCount(COMPANY_NUMBER);
+        int result = shareholderRepository.getShareholderCount(COMPANY_NUMBER);
 
         assertEquals(1, result);
     }
@@ -94,10 +94,10 @@ class ShareholderDaoTest {
     @Test
     @DisplayName("Get shareholders count - company with elected shareholders")
     void getShareholderCountFromShareholdersElectedTableTest() {
-        when(jdbcTemplate.queryForObject(eq(ShareholderDao.SHAREHOLDER_COUNT_SQL), eq(Integer.class),
+        when(jdbcTemplate.queryForObject(eq(ShareholderRepository.SHAREHOLDER_COUNT_SQL), eq(Integer.class),
                 eq(COMPANY_NUMBER))).thenReturn(2);
 
-        int result = dao.getShareholderCount(COMPANY_NUMBER);
+        int result = shareholderRepository.getShareholderCount(COMPANY_NUMBER);
 
         assertEquals(2, result);
     }
@@ -107,7 +107,7 @@ class ShareholderDaoTest {
     void getShareholderCountForCorporateBodyWithNoneTest() {
         when(jdbcTemplate.queryForObject(any(), eq(Integer.class), eq(COMPANY_NUMBER))).thenReturn(0);
 
-        int result = dao.getShareholderCount(COMPANY_NUMBER);
+        int result = shareholderRepository.getShareholderCount(COMPANY_NUMBER);
 
         assertEquals(0, result);
     }

--- a/src/test/java/uk/gov/ch/service/shareholder/impl/ShareholderServiceImplTest.java
+++ b/src/test/java/uk/gov/ch/service/shareholder/impl/ShareholderServiceImplTest.java
@@ -1,18 +1,17 @@
-package uk.gov.ch.service.impl;
+package uk.gov.ch.service.shareholder.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import uk.gov.ch.dao.ShareholderDao;
-import uk.gov.ch.model.Shareholder;
+import uk.gov.ch.repository.shareholder.ShareholderRepository;
+import uk.gov.ch.model.shareholder.Shareholder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,14 +22,14 @@ class ShareholderServiceImplTest {
     private static final String COMPANY_NUMBER = "123456789";
 
     @Mock
-    private ShareholderDao shareholderDao;
+    private ShareholderRepository shareholderRepository;
 
     @InjectMocks
     private ShareholderServiceImpl shareholderService;
 
     @Test
     void getShareholderCount() {
-        when(shareholderDao.getShareholderCount(any())).thenReturn(3);
+        when(shareholderRepository.getShareholderCount(any())).thenReturn(3);
 
         int result = shareholderService.getShareholderCount(COMPANY_NUMBER);
 
@@ -42,7 +41,7 @@ class ShareholderServiceImplTest {
         List<Shareholder> expectedList = new ArrayList<Shareholder>();
         expectedList.add(new Shareholder());
 
-        when(shareholderDao.getShareholders(any())).thenReturn(expectedList);
+        when(shareholderRepository.getShareholders(any())).thenReturn(expectedList);
 
         List<Shareholder> result = shareholderService.getShareholders(COMPANY_NUMBER);
 


### PR DESCRIPTION
…query-api folder structure

The shareholder service and other related files weren't in their own 'shareholder' folder like the other services so moved them into their own folders to keep it consistent with the rest of the existing code.