### PR TITLE
NCS-447 Removing elected shareholder queries

### DIFF
--- a/src/main/java/uk/gov/ch/repository/shareholder/ShareholderRepository.java
+++ b/src/main/java/uk/gov/ch/repository/shareholder/ShareholderRepository.java
@@ -1,7 +1,5 @@
 package uk.gov.ch.repository.shareholder;
 
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,22 +28,10 @@ public class ShareholderRepository {
         + "FROM shareholder sh INNER JOIN shareholding shd ON sh.shareholding_id = shd.shareholding_id "
         + "JOIN corporate_body cb on cb.corporate_body_id = shd.corporate_body_id WHERE cb.incorporation_number = ?";
 
-    static final String SHAREHOLDER_ELECTED_LIST_SQL = "SELECT sh.shareholder_elected_forename_1 as forename1, sh.shareholder_elected_forename_2 as forename2, sh.shareholder_elected_surname as surname, "
-        + "sh.address_id as addressId, shd.number_of_shares as shares, shd.share_class_type_id as shareClassTypeId, shd.currency_type_id as currencyTypeId "
-        + "FROM shareholder_elected sh JOIN sholdingelc_sholderelc_link shl ON sh.shareholder_elected_id = shl.shareholder_elected_id "
-        + "INNER JOIN shareholding_elected shd ON shd.shareholding_elected_id = shl.shareholding_elected_id "
-        + "JOIN corporate_body cb on cb.corporate_body_id = shd.corporate_body_id WHERE cb.incorporation_number = ?";
-
     public List<Shareholder> getShareholders(String incorporationNumber) {
         List<Shareholder> list = jdbcTemplate.query(SHAREHOLDER_LIST_SQL, getParam(incorporationNumber), new BeanPropertyRowMapper<>(Shareholder.class));
 
         LOGGER.info("Returned " + list.size() + " shareholders from SHAREHOLDER tables.");
-
-        if (list.isEmpty()) {
-            list = jdbcTemplate.query(SHAREHOLDER_ELECTED_LIST_SQL, getParam(incorporationNumber), new BeanPropertyRowMapper<>(Shareholder.class));
-
-            LOGGER.info("Returned " + list.size() + " shareholders from SHAREHOLDER_ELECTED tables.");
-        }
 
         return list;
     }
@@ -59,11 +45,7 @@ public class ShareholderRepository {
     }
 
     private PreparedStatementSetter getParam(String param) {
-        return  new PreparedStatementSetter() {
-            public void setValues(PreparedStatement preparedStatement) throws SQLException {
-                preparedStatement.setString(1, param);
-            }
-        };
+        return preparedStatement -> preparedStatement.setString(1, param);
     }
 
 }

--- a/src/test/java/uk/gov/ch/repository/shareholder/ShareholderRepositoryTest.java
+++ b/src/test/java/uk/gov/ch/repository/shareholder/ShareholderRepositoryTest.java
@@ -4,8 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -44,31 +42,13 @@ class ShareholderRepositoryTest {
 
         List<Shareholder> resultList = shareholderRepository.getShareholders(COMPANY_NUMBER);
 
-        verify(jdbcTemplate, times(0)).query(eq(ShareholderRepository.SHAREHOLDER_ELECTED_LIST_SQL), any(PreparedStatementSetter.class), any(BeanPropertyRowMapper.class));
-
         assertEquals(expectedList, resultList);
         assertEquals(1, resultList.size());
 
     }
 
     @Test
-    @DisplayName("Get shareholders - company with elected shareholders")
-    void getShareholdersFromShareholdersElectedTableTest() {
-        List<Shareholder> expectedList = new ArrayList<Shareholder>();
-        expectedList.add(new Shareholder());
-
-        when(jdbcTemplate.query(eq(ShareholderRepository.SHAREHOLDER_LIST_SQL), any(PreparedStatementSetter.class), any(BeanPropertyRowMapper.class))).thenReturn(new ArrayList<Shareholder>());
-
-        when(jdbcTemplate.query(eq(ShareholderRepository.SHAREHOLDER_ELECTED_LIST_SQL), any(PreparedStatementSetter.class), any(BeanPropertyRowMapper.class))).thenReturn(expectedList);
-
-        List<Shareholder> resultList = shareholderRepository.getShareholders(COMPANY_NUMBER);
-
-        assertEquals(expectedList, resultList);
-        assertEquals(1, resultList.size());
-    }
-
-    @Test
-    @DisplayName("Get shareholders - company with neither shareholders nor elected shareholders")
+    @DisplayName("Get shareholders - company with no shareholders")
     void getShareholdersForCorporateBodyWithNoneTest() {
         List<Shareholder> expectedList = new ArrayList<Shareholder>();
 
@@ -92,18 +72,7 @@ class ShareholderRepositoryTest {
     }
 
     @Test
-    @DisplayName("Get shareholders count - company with elected shareholders")
-    void getShareholderCountFromShareholdersElectedTableTest() {
-        when(jdbcTemplate.queryForObject(eq(ShareholderRepository.SHAREHOLDER_COUNT_SQL), eq(Integer.class),
-                eq(COMPANY_NUMBER))).thenReturn(2);
-
-        int result = shareholderRepository.getShareholderCount(COMPANY_NUMBER);
-
-        assertEquals(2, result);
-    }
-
-    @Test
-    @DisplayName("Get shareholders count - company with neither shareholders nor elected shareholders")
+    @DisplayName("Get shareholders count - company with no shareholders")
     void getShareholderCountForCorporateBodyWithNoneTest() {
         when(jdbcTemplate.queryForObject(any(), eq(Integer.class), eq(COMPANY_NUMBER))).thenReturn(0);
 


### PR DESCRIPTION
Previous PR https://github.com/companieshouse/oracle-query-api/pull/47 was to remove the elected shareholder part of the query from the shareholder count. This PR is to also remove it from the shareholder list as it is now deemed to be out of scope.