### PR TITLE
NCS-631 Endpoint and query structure for cs payment check

### DIFF
--- a/src/main/java/uk/gov/ch/controller/payment/ConfirmationStatementPaymentCheckController.java
+++ b/src/main/java/uk/gov/ch/controller/payment/ConfirmationStatementPaymentCheckController.java
@@ -1,0 +1,23 @@
+package uk.gov.ch.controller.payment;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.ch.service.payment.ConfirmationStatementPaymentCheckService;
+
+@RestController
+public class ConfirmationStatementPaymentCheckController {
+
+    @Autowired
+    private ConfirmationStatementPaymentCheckService confirmationStatementPaymentCheckService;
+
+    @GetMapping("/company/{companyNumber}/confirmation-statement/paid")
+    public ResponseEntity<Boolean> isConfirmationStatementPaid(@PathVariable String companyNumber, @RequestParam("paymentPeriodDueDate") String dueDate) {
+        boolean isConfirmationStatementPaid = confirmationStatementPaymentCheckService.isConfirmationStatementPaid(companyNumber, dueDate);
+        return ResponseEntity.status(HttpStatus.OK).body(isConfirmationStatementPaid);
+    }
+}

--- a/src/main/java/uk/gov/ch/model/payment/ConfirmationStatementPayment.java
+++ b/src/main/java/uk/gov/ch/model/payment/ConfirmationStatementPayment.java
@@ -1,0 +1,20 @@
+package uk.gov.ch.model.payment;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+public class ConfirmationStatementPayment {
+    @Id
+    @Column(name = "PAID_BY_TRANSACTION_ID")
+    private Long paidByTransactionId;
+
+    public Long getPaidByTransactionId() {
+        return paidByTransactionId;
+    }
+
+    public void setPaidByTransactionId(Long paidByTransactionId) {
+        this.paidByTransactionId = paidByTransactionId;
+    }
+}

--- a/src/main/java/uk/gov/ch/repository/payment/ConfirmationStatementPaymentCheckRepository.java
+++ b/src/main/java/uk/gov/ch/repository/payment/ConfirmationStatementPaymentCheckRepository.java
@@ -1,0 +1,19 @@
+package uk.gov.ch.repository.payment;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import uk.gov.ch.model.payment.ConfirmationStatementPayment;
+
+import java.sql.Date;
+import java.util.Optional;
+
+
+public interface ConfirmationStatementPaymentCheckRepository extends CrudRepository<ConfirmationStatementPayment, Long> {
+
+    @Query(value = "select " +
+           "CSPP.paid_by_transaction_id " +
+           "from CORPORATE_BODY CB " +
+           "inner join CONFIRMATION_STMT_PYMT_PERIOD CSPP on CB.CORPORATE_BODY_ID=CSPP.CORPORATE_BODY_ID " +
+           "where CB.INCORPORATION_NUMBER=?1 and CSPP.PAYMENT_PERIOD_DUE_DATE=?2", nativeQuery = true)
+    Optional<ConfirmationStatementPayment> findPaymentsForPeriod(String companyNumber, Date dueDate);
+}

--- a/src/main/java/uk/gov/ch/repository/payment/ConfirmationStatementPaymentCheckRepository.java
+++ b/src/main/java/uk/gov/ch/repository/payment/ConfirmationStatementPaymentCheckRepository.java
@@ -7,7 +7,6 @@ import uk.gov.ch.model.payment.ConfirmationStatementPayment;
 import java.sql.Date;
 import java.util.Optional;
 
-
 public interface ConfirmationStatementPaymentCheckRepository extends CrudRepository<ConfirmationStatementPayment, Long> {
 
     @Query(value = "select " +

--- a/src/main/java/uk/gov/ch/service/payment/ConfirmationStatementPaymentCheckService.java
+++ b/src/main/java/uk/gov/ch/service/payment/ConfirmationStatementPaymentCheckService.java
@@ -1,0 +1,8 @@
+package uk.gov.ch.service.payment;
+
+import java.time.LocalDate;
+
+public interface ConfirmationStatementPaymentCheckService {
+
+    boolean isConfirmationStatementPaid(String companyNumber, String dueDate);
+}

--- a/src/main/java/uk/gov/ch/service/payment/ConfirmationStatementPaymentCheckService.java
+++ b/src/main/java/uk/gov/ch/service/payment/ConfirmationStatementPaymentCheckService.java
@@ -1,7 +1,5 @@
 package uk.gov.ch.service.payment;
 
-import java.time.LocalDate;
-
 public interface ConfirmationStatementPaymentCheckService {
 
     boolean isConfirmationStatementPaid(String companyNumber, String dueDate);

--- a/src/main/java/uk/gov/ch/service/payment/impl/ConfirmationStatementPaymentCheckServiceImpl.java
+++ b/src/main/java/uk/gov/ch/service/payment/impl/ConfirmationStatementPaymentCheckServiceImpl.java
@@ -43,5 +43,4 @@ public class ConfirmationStatementPaymentCheckServiceImpl implements Confirmatio
         LOGGER.info("Confirmation statement payment query returned no result");
         return false;
     }
-
 }

--- a/src/main/java/uk/gov/ch/service/payment/impl/ConfirmationStatementPaymentCheckServiceImpl.java
+++ b/src/main/java/uk/gov/ch/service/payment/impl/ConfirmationStatementPaymentCheckServiceImpl.java
@@ -1,0 +1,47 @@
+package uk.gov.ch.service.payment.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.ch.OracleQueryApplication;
+import uk.gov.ch.model.payment.ConfirmationStatementPayment;
+import uk.gov.ch.repository.payment.ConfirmationStatementPaymentCheckRepository;
+import uk.gov.ch.service.payment.ConfirmationStatementPaymentCheckService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+@Service
+public class ConfirmationStatementPaymentCheckServiceImpl implements ConfirmationStatementPaymentCheckService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OracleQueryApplication.APPLICATION_NAME_SPACE);
+    private static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    @Autowired
+    private ConfirmationStatementPaymentCheckRepository confirmationStatementPaymentCheckRepository;
+
+    @Override
+    public boolean isConfirmationStatementPaid(String companyNumber, String dueDateString) {
+        LocalDate dueDate = LocalDate.parse(dueDateString, dateTimeFormatter);
+        Optional<ConfirmationStatementPayment> confirmationStatementPayment
+                = confirmationStatementPaymentCheckRepository.findPaymentsForPeriod(companyNumber, Date.valueOf(dueDate));
+
+        if(confirmationStatementPayment.isPresent()) {
+            Long paidByTransactionId = confirmationStatementPayment.get().getPaidByTransactionId();
+
+            if(paidByTransactionId != null) {
+                LOGGER.info("Confirmation statement payment id " +
+                        paidByTransactionId + " found for due date " + dueDateString);
+                return true;
+            }
+            LOGGER.info("Confirmation statement payment query returned result but no payment transaction id found");
+            return false;
+        }
+        LOGGER.info("Confirmation statement payment query returned no result");
+        return false;
+    }
+
+}

--- a/src/test/java/uk/gov/ch/controller/payment/ConfirmationStatementPaymentCheckControllerTest.java
+++ b/src/test/java/uk/gov/ch/controller/payment/ConfirmationStatementPaymentCheckControllerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ch.controller.payment;
 
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -16,12 +15,11 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class ConfirmationStatementPaymentCheckControllerTest {
 
-    private static final Long PAID_BY_TRANSACTION_ID = 01234L;
     private static String COMPANY_NUMBER = "01234567";
     private static String DUE_DATE = "2022-01-01";
 
     @InjectMocks
-    private ConfirmationStatementPaymentCheckController confirmationStatementPaymentCheckContoller;
+    private ConfirmationStatementPaymentCheckController confirmationStatementPaymentCheckController;
 
     @Mock
     private ConfirmationStatementPaymentCheckService confirmationStatementPaymentCheckService;
@@ -29,7 +27,7 @@ class ConfirmationStatementPaymentCheckControllerTest {
     @Test
     void testIsConfirmationStatementPaid() {
         when(confirmationStatementPaymentCheckService.isConfirmationStatementPaid(COMPANY_NUMBER, DUE_DATE)).thenReturn(true);
-        ResponseEntity<Boolean> response = confirmationStatementPaymentCheckContoller.isConfirmationStatementPaid(COMPANY_NUMBER, DUE_DATE);
+        ResponseEntity<Boolean> response = confirmationStatementPaymentCheckController.isConfirmationStatementPaid(COMPANY_NUMBER, DUE_DATE);
         assertEquals(HttpStatus.OK,response.getStatusCode());
         assertEquals(Boolean.TRUE,response.getBody());
     }

--- a/src/test/java/uk/gov/ch/controller/payment/ConfirmationStatementPaymentCheckControllerTest.java
+++ b/src/test/java/uk/gov/ch/controller/payment/ConfirmationStatementPaymentCheckControllerTest.java
@@ -1,0 +1,36 @@
+package uk.gov.ch.controller.payment;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import uk.gov.ch.service.payment.ConfirmationStatementPaymentCheckService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ConfirmationStatementPaymentCheckControllerTest {
+
+    private static final Long PAID_BY_TRANSACTION_ID = 01234L;
+    private static String COMPANY_NUMBER = "01234567";
+    private static String DUE_DATE = "2022-01-01";
+
+    @InjectMocks
+    private ConfirmationStatementPaymentCheckController confirmationStatementPaymentCheckContoller;
+
+    @Mock
+    private ConfirmationStatementPaymentCheckService confirmationStatementPaymentCheckService;
+
+    @Test
+    void testIsConfirmationStatementPaid() {
+        when(confirmationStatementPaymentCheckService.isConfirmationStatementPaid(COMPANY_NUMBER, DUE_DATE)).thenReturn(true);
+        ResponseEntity<Boolean> response = confirmationStatementPaymentCheckContoller.isConfirmationStatementPaid(COMPANY_NUMBER, DUE_DATE);
+        assertEquals(HttpStatus.OK,response.getStatusCode());
+        assertEquals(Boolean.TRUE,response.getBody());
+    }
+}

--- a/src/test/java/uk/gov/ch/service/payment/impl/ConfirmationStatementPaymentCheckServiceImplTest.java
+++ b/src/test/java/uk/gov/ch/service/payment/impl/ConfirmationStatementPaymentCheckServiceImplTest.java
@@ -31,7 +31,6 @@ class ConfirmationStatementPaymentCheckServiceImplTest {
     @Mock
     private ConfirmationStatementPaymentCheckRepository confirmationStatementPaymentCheckRepository;
 
-
     @Test
     void testIsConfirmationStatementPaid() {
         ConfirmationStatementPayment confirmationStatementPayment = new ConfirmationStatementPayment();

--- a/src/test/java/uk/gov/ch/service/payment/impl/ConfirmationStatementPaymentCheckServiceImplTest.java
+++ b/src/test/java/uk/gov/ch/service/payment/impl/ConfirmationStatementPaymentCheckServiceImplTest.java
@@ -1,0 +1,66 @@
+package uk.gov.ch.service.payment.impl;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.ch.OracleQueryApplication;
+import uk.gov.ch.model.payment.ConfirmationStatementPayment;
+import uk.gov.ch.repository.payment.ConfirmationStatementPaymentCheckRepository;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ConfirmationStatementPaymentCheckServiceImplTest {
+
+    private static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private static final Long PAID_BY_TRANSACTION_ID = 01234L;
+    private static String COMPANY_NUMBER = "01234567";
+    private static String DUE_DATE = "2022-01-01";
+
+    @InjectMocks
+    private ConfirmationStatementPaymentCheckServiceImpl confirmationStatementPaymentCheckServiceImpl;
+
+    @Mock
+    private ConfirmationStatementPaymentCheckRepository confirmationStatementPaymentCheckRepository;
+
+
+    @Test
+    void testIsConfirmationStatementPaid() {
+        ConfirmationStatementPayment confirmationStatementPayment = new ConfirmationStatementPayment();
+        confirmationStatementPayment.setPaidByTransactionId(PAID_BY_TRANSACTION_ID);
+        Date dueDateSql = Date.valueOf(LocalDate.parse(DUE_DATE, dateTimeFormatter));
+        when(confirmationStatementPaymentCheckRepository.findPaymentsForPeriod(COMPANY_NUMBER, dueDateSql)).thenReturn(Optional.of(confirmationStatementPayment));
+        boolean isPaid = confirmationStatementPaymentCheckServiceImpl.isConfirmationStatementPaid(COMPANY_NUMBER, DUE_DATE);
+        assertTrue(isPaid);
+    }
+
+    @Test
+    void testIsNotConfirmationStatementPaidForEmptyResult() {
+        ConfirmationStatementPayment confirmationStatementPayment = new ConfirmationStatementPayment();
+        confirmationStatementPayment.setPaidByTransactionId(PAID_BY_TRANSACTION_ID);
+        Date dueDateSql = Date.valueOf(LocalDate.parse(DUE_DATE, dateTimeFormatter));
+        when(confirmationStatementPaymentCheckRepository.findPaymentsForPeriod(COMPANY_NUMBER, dueDateSql)).thenReturn(Optional.empty());
+        boolean isPaid = confirmationStatementPaymentCheckServiceImpl.isConfirmationStatementPaid(COMPANY_NUMBER, DUE_DATE);
+        assertFalse(isPaid);
+    }
+
+    @Test
+    void testIsNotConfirmationStatementPaidForResultButNoId() {
+        ConfirmationStatementPayment confirmationStatementPayment = new ConfirmationStatementPayment();
+        Date dueDateSql = Date.valueOf(LocalDate.parse(DUE_DATE, dateTimeFormatter));
+        when(confirmationStatementPaymentCheckRepository.findPaymentsForPeriod(COMPANY_NUMBER, dueDateSql)).thenReturn(Optional.of(confirmationStatementPayment));
+        boolean isPaid = confirmationStatementPaymentCheckServiceImpl.isConfirmationStatementPaid(COMPANY_NUMBER, DUE_DATE);
+        assertFalse(isPaid);
+    }
+}

--- a/src/test/java/uk/gov/ch/service/payment/impl/ConfirmationStatementPaymentCheckServiceImplTest.java
+++ b/src/test/java/uk/gov/ch/service/payment/impl/ConfirmationStatementPaymentCheckServiceImplTest.java
@@ -1,13 +1,10 @@
 package uk.gov.ch.service.payment.impl;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.ch.OracleQueryApplication;
 import uk.gov.ch.model.payment.ConfirmationStatementPayment;
 import uk.gov.ch.repository.payment.ConfirmationStatementPaymentCheckRepository;
 


### PR DESCRIPTION
SQL query to decide if paid by transaction id is present for a company at a certain due date.

Believe we need to include logging to show the id we get back from the query so as to ensure there are no false positives and also to provide details of why false has been returned. Having a query result with no id is a very unlikely edge case but cannot guarentee this will never happen so covered that too.

Will add another update spec and readme, perhaps include cs api.