### PR TITLE
Fix simple code smells

### DIFF
--- a/src/main/java/uk/gov/ch/controller/transaction/TransactionController.java
+++ b/src/main/java/uk/gov/ch/controller/transaction/TransactionController.java
@@ -1,7 +1,6 @@
 package uk.gov.ch.controller.transaction;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,7 +13,6 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.ch.OracleQueryApplication;
 import uk.gov.ch.exception.TransactionMappingException;
 import uk.gov.ch.service.transaction.TransactionService;
-import uk.gov.companieshouse.api.model.filinghistory.FilingApi;
 import uk.gov.companieshouse.api.model.filinghistory.FilingHistoryApi;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;

--- a/src/test/java/uk/gov/ch/controller/emergencyauthcode/EmergencyOfficersControllerTest.java
+++ b/src/test/java/uk/gov/ch/controller/emergencyauthcode/EmergencyOfficersControllerTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class EmergencyOfficersControllerTest {
+class EmergencyOfficersControllerTest {
 
     @Mock
     EmergencyOfficersService mockEmergencyOfficersService;
@@ -40,7 +40,7 @@ public class EmergencyOfficersControllerTest {
 
     @Test
     @DisplayName("Get list of eligible officers - no company not found")
-    public void testGetEligibleOfficersNoCompanyFound() {
+    void testGetEligibleOfficersNoCompanyFound() {
 
         when(mockEmergencyOfficersService.getEligibleOfficersEmergencyAuthCode(INCORPORATION_NUMBER, pageable)).thenReturn(null);
 
@@ -50,7 +50,7 @@ public class EmergencyOfficersControllerTest {
 
     @Test
     @DisplayName("Get list of eligible officers - no eligible officers found")
-    public void testGetEligibleOfficersNoOfficersFound() {
+    void testGetEligibleOfficersNoOfficersFound() {
         when(mockEmergencyOfficersService.getEligibleOfficersEmergencyAuthCode(INCORPORATION_NUMBER, pageable)).thenReturn(corporateBodyAppointmentsNoOfficers());
 
         ResponseEntity<CorporateBodyAppointments> returnedEligibleOfficers = controller.getListOfEligibleCompanyOfficers(INCORPORATION_NUMBER, START_INDEX, ITEMS_PER_PAGE);
@@ -59,7 +59,7 @@ public class EmergencyOfficersControllerTest {
 
     @Test
     @DisplayName("Get list of eligible officers - success path")
-    public void testGetEligibleOfficersForCompanySuccess() {
+    void testGetEligibleOfficersForCompanySuccess() {
 
         when(mockEmergencyOfficersService.getEligibleOfficersEmergencyAuthCode(INCORPORATION_NUMBER, pageable)).thenReturn(corporateBodyAppointments());
 
@@ -71,7 +71,7 @@ public class EmergencyOfficersControllerTest {
 
     @Test
     @DisplayName("Get eligible officer - no eligible officer found")
-    public void testGetEligibleOfficerNoOfficerFound() {
+    void testGetEligibleOfficerNoOfficerFound() {
         when(mockEmergencyOfficersService.getEligibleOfficer(INCORPORATION_NUMBER, OFFICER_ID)).thenReturn(null);
 
         ResponseEntity<CorporateBodyAppointment> returnedEligibleOfficer = controller.getCompanyOfficer(INCORPORATION_NUMBER, OFFICER_ID);
@@ -80,7 +80,7 @@ public class EmergencyOfficersControllerTest {
 
     @Test
     @DisplayName(("Get eligible officer - success path"))
-    public void testGetEligibleOfficerSuccess() {
+    void testGetEligibleOfficerSuccess() {
 
         when(mockEmergencyOfficersService.getEligibleOfficer(INCORPORATION_NUMBER, OFFICER_ID)).thenReturn(new CorporateBodyAppointment());
 
@@ -90,7 +90,7 @@ public class EmergencyOfficersControllerTest {
 
     @Test
     @DisplayName(("Get filing history - has not filed in past 30 days"))
-    public void testGetFilingHistoryHasNotFiled() {
+    void testGetFilingHistoryHasNotFiled() {
         CorporateBodyEFilingStatus corporateBodyEFilingStatus = new CorporateBodyEFilingStatus();
         corporateBodyEFilingStatus.setEfilingFoundInPeriod(false);
         when(mockEmergencyOfficersService.checkIfEFiledLastThirtyDays(INCORPORATION_NUMBER)).thenReturn(corporateBodyEFilingStatus);
@@ -102,7 +102,7 @@ public class EmergencyOfficersControllerTest {
 
     @Test
     @DisplayName(("Get filing history - has filed in past 30 days"))
-    public void testGetFilingHistoryHasFiled() {
+    void testGetFilingHistoryHasFiled() {
         CorporateBodyEFilingStatus corporateBodyEFilingStatus = new CorporateBodyEFilingStatus();
         corporateBodyEFilingStatus.setEfilingFoundInPeriod(true);
         when(mockEmergencyOfficersService.checkIfEFiledLastThirtyDays(INCORPORATION_NUMBER)).thenReturn(corporateBodyEFilingStatus);

--- a/src/test/java/uk/gov/ch/service/emergencyauthcode/impl/EmergencyOfficersServiceImplTest.java
+++ b/src/test/java/uk/gov/ch/service/emergencyauthcode/impl/EmergencyOfficersServiceImplTest.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class EmergencyOfficersServiceImplTest {
+class EmergencyOfficersServiceImplTest {
 
     @Mock
     EmergencyAuthCodeEligibleOfficersRepository mockRepo;
@@ -48,7 +48,7 @@ public class EmergencyOfficersServiceImplTest {
 
     @Test
     @DisplayName("Get eligible officers for emergency-auth-code from repository")
-    public void testGetEligibleOfficersFromRepository() {
+    void testGetEligibleOfficersFromRepository() {
         Page<CorporateBodyAppointmentDataModel> mockRepoResponse = getMockEmergencyAuthCodeRepo();
         when(mockRepo.findEligibleOfficersEmergencyAuthCode(INCORPORATION_NUMBER, pageable)).thenReturn(mockRepoResponse);
 
@@ -63,7 +63,7 @@ public class EmergencyOfficersServiceImplTest {
 
     @Test
     @DisplayName("Get eligible officer returns null from repository")
-    public void testGetEligibleOfficerReturnsNull() {
+    void testGetEligibleOfficerReturnsNull() {
         when(mockRepo.findEligibleOfficer(INCORPORATION_NUMBER, OFFICER_ID)).thenReturn(null);
 
         CorporateBodyAppointment returnedCorporateBodyAppointment = service.getEligibleOfficer(INCORPORATION_NUMBER, OFFICER_ID);
@@ -72,7 +72,7 @@ public class EmergencyOfficersServiceImplTest {
 
     @Test
     @DisplayName("Get eligible officer for emergency-auth-code from repository")
-    public void testGetEligibleOfficerFromRepository() {
+    void testGetEligibleOfficerFromRepository() {
         CorporateBodyAppointmentDataModel mockRepoResponse = new CorporateBodyAppointmentDataModel() {{
             setCorporateBodyAppointmentId(123L);
             setOccupationDescription("description");
@@ -92,7 +92,7 @@ public class EmergencyOfficersServiceImplTest {
 
     @Test
     @DisplayName("Get filing history for company returns filing in past 30 days")
-    public void testGetFilingHistoryReturnsFiling() {
+    void testGetFilingHistoryReturnsFiling() {
         when(mockRepo.findEFilingsInLastThirtyDays(INCORPORATION_NUMBER)).thenReturn(1L);
 
         CorporateBodyEFilingStatus corporateBodyEFilingStatus = service.checkIfEFiledLastThirtyDays(INCORPORATION_NUMBER);
@@ -101,7 +101,7 @@ public class EmergencyOfficersServiceImplTest {
 
     @Test
     @DisplayName("Get filing history for company returns no filing in past 30 days")
-    public void testGetFilingHistoryReturnsNoFiling() {
+    void testGetFilingHistoryReturnsNoFiling() {
         when(mockRepo.findEFilingsInLastThirtyDays(INCORPORATION_NUMBER)).thenReturn(0L);
 
         CorporateBodyEFilingStatus corporateBodyEFilingStatus = service.checkIfEFiledLastThirtyDays(INCORPORATION_NUMBER);


### PR DESCRIPTION
The Oracle query api has 18 code smells - started by clearing the simple ones up.