### PR TITLE
Added check for accounting reference date values

### DIFF
--- a/src/main/java/uk/gov/ch/transformers/corporatebody/CorporateBodyTransformer.java
+++ b/src/main/java/uk/gov/ch/transformers/corporatebody/CorporateBodyTransformer.java
@@ -27,6 +27,7 @@ import uk.gov.companieshouse.api.model.company.account.NextAccountsApi;
 public class CorporateBodyTransformer {
     
     private static final List<String> COMPANY_STATUS_DETAIL = Arrays.asList("5", "Q", "R", "X", "Z", "AA", "AB");
+    private static final String ARD_DEFAULT_STRING = "99";
 
     public CompanyProfileApi convert(CompanyProfileModel model) {
         CompanyProfileApi companyProfileApi = new CompanyProfileApi();
@@ -123,8 +124,14 @@ public class CorporateBodyTransformer {
     private CompanyAccountApi getAccounts(CompanyProfileModel model) {
         CompanyAccountApi companyAccountApi = new CompanyAccountApi();
         AccountingReferenceDateApi accountingReferenceDateApi = new AccountingReferenceDateApi();
-        accountingReferenceDateApi.setDay(model.getAccRefDate().substring(0,2));
-        accountingReferenceDateApi.setMonth(model.getAccRefDate().substring(2));
+        if(model.getAccRefDate() != null && !model.getAccRefDate().isEmpty()) {
+            if(!model.getAccRefDate().substring(0,2).equalsIgnoreCase(ARD_DEFAULT_STRING)) {                
+                accountingReferenceDateApi.setDay(model.getAccRefDate().substring(0,2));
+            }
+            if(!model.getAccRefDate().substring(2).equalsIgnoreCase(ARD_DEFAULT_STRING)) {                
+                accountingReferenceDateApi.setMonth(model.getAccRefDate().substring(2));
+            }
+        }
         companyAccountApi.setAccountingReferenceDate(accountingReferenceDateApi);
         if (model.getAccountingDates() != null) {
             companyAccountApi.setNextDue(getLocalDateFromString(model.getAccountingDates().getNextDue()));

--- a/src/test/java/uk/gov/ch/transformers/corporatebody/CorporateBodyTransformerTest.java
+++ b/src/test/java/uk/gov/ch/transformers/corporatebody/CorporateBodyTransformerTest.java
@@ -126,6 +126,21 @@ class CorporateBodyTransformerTest {
         assertPreviousNames(model, result);
         assertSicCodes(model, result);   
     }
+    
+    @Test
+    @DisplayName("Test ARD with null and default values, should return null ARD dates")
+    void testConvertWithNullOrDefaultARD() {
+        CompanyProfileModel model = setUpModel();
+        model.setAccRefDate(null);
+        CompanyProfileApi result = transformer.convert(model);
+        assertNull(result.getAccounts().getAccountingReferenceDate().getDay());
+        assertNull(result.getAccounts().getAccountingReferenceDate().getMonth());
+        
+        model.setAccRefDate("9999");
+        CompanyProfileApi secondResult = transformer.convert(model);
+        assertNull(secondResult.getAccounts().getAccountingReferenceDate().getDay());
+        assertNull(secondResult.getAccounts().getAccountingReferenceDate().getMonth());
+    }
 
     private void assertSicCodes(CompanyProfileModel model, CompanyProfileApi result) {
         assertEquals(5, result.getSicCodes().length);


### PR DESCRIPTION
Check if the default value of Accounting Reference Day - day or month is 99. If so, replace with a null value