### PR TITLE
Upgrade structured logging for log4j vulnerability fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
         <spring-test.version>5.1.3.RELEASE</spring-test.version>
         <hamcrest.version>2.1</hamcrest.version>
         <org.mapstruct.version>1.3.1.Final</org.mapstruct.version>
-        <structured-logging.version>1.5.0-rc2</structured-logging.version>
 
         <!-- Maven -->
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
@@ -46,21 +45,27 @@
     <dependencies>
 
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.15.0</version>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>3.4.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
+            <artifactId>log4j-core</artifactId>
             <version>2.15.0</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.16.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-to-slf4j</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <spring.boot.version>2.4.0</spring.boot.version>
         <java.version>1.8</java.version>
-        <structured-logging.version>1.9.10</structured-logging.version>
+        <structured-logging.version>1.9.11</structured-logging.version>
         <thymeleaf-layout-dialect.version>2.3.0</thymeleaf-layout-dialect.version>
         <sdk-manager-java.version>1.5.2</sdk-manager-java.version>
         <api-sdk-java.version>4.3.7</api-sdk-java.version>
@@ -48,24 +48,6 @@
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
             <version>3.4.1</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.15.0</version>
-        </dependency>
-        
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>2.16.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-to-slf4j</artifactId>
-            <version>2.16.0</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -45,12 +45,6 @@
     <dependencies>
 
         <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-utils</artifactId>
-            <version>3.4.1</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <version>${spring.boot.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <spring.boot.version>2.4.0</spring.boot.version>
         <java.version>1.8</java.version>
-        <structured-logging.version>1.5.0-rc2</structured-logging.version>
+        <structured-logging.version>1.9.10</structured-logging.version>
         <thymeleaf-layout-dialect.version>2.3.0</thymeleaf-layout-dialect.version>
         <sdk-manager-java.version>1.5.2</sdk-manager-java.version>
         <api-sdk-java.version>4.3.7</api-sdk-java.version>
@@ -44,6 +44,25 @@
     </properties>
 
     <dependencies>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.15.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.15.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>2.15.0</version>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>

--- a/src/main/java/uk/gov/ch/util/CustomTextFormat.java
+++ b/src/main/java/uk/gov/ch/util/CustomTextFormat.java
@@ -1,6 +1,6 @@
 package uk.gov.ch.util;
 
-import org.codehaus.plexus.util.StringUtils;
+import org.apache.commons.lang.StringUtils;
 
 public class CustomTextFormat {
 
@@ -16,7 +16,7 @@ public class CustomTextFormat {
 
         StringBuilder stringBuilder = new StringBuilder();
         for (String sub : text.toLowerCase().split("\\. ")) {
-            stringBuilder.append(". ").append(StringUtils.capitalizeFirstLetter(sub));
+            stringBuilder.append(". ").append(StringUtils.capitalize(sub));
         }
         return stringBuilder.delete(0,1).toString().trim();
     }


### PR DESCRIPTION
Resolves [DEBT-1460](https://companieshouse.atlassian.net/browse/DEBT-1460)

Upgrading structured logging to version 1.9.11 ; changing import from plexus-utils to apache-utils in CustomTextFormat to resolve codehaus error.