### PR TITLE
BI-10611 Changing PSC model to use house name number as ura address l…

### DIFF
--- a/src/main/java/uk/gov/ch/model/psc/PersonWithSignificantControl.java
+++ b/src/main/java/uk/gov/ch/model/psc/PersonWithSignificantControl.java
@@ -46,6 +46,8 @@ public class PersonWithSignificantControl {
     private String usualResidentialCountry;
     @Column(name = "OFFICER_DATE_OF_BIRTH")
     private String officerDateOfBirth;
+    @Column(name = "HOUSE_NAME_NUMBER")
+    private String houseNameNumber;
     @Column(name = "STREET")
     private String street;
     @Column(name = "POST_TOWN")
@@ -99,7 +101,7 @@ public class PersonWithSignificantControl {
 
     public Address getAddress() {
         address = new Address();
-        address.setAddressLine1(addressLine1);
+        address.setAddressLine1(houseNameNumber);
         address.setAddressLine2(street);
         address.setCareOf(careOf);
         address.setCountry(countryName);
@@ -300,5 +302,13 @@ public class PersonWithSignificantControl {
 
     public void setServiceAddressLine2(String serviceAddressLine2) {
         this.serviceAddressLine2 = serviceAddressLine2;
+    }
+
+    public String getHouseNameNumber() {
+        return houseNameNumber;
+    }
+
+    public void setHouseNameNumber(String houseNameNumber) {
+        this.houseNameNumber = houseNameNumber;
     }
 }

--- a/src/test/java/uk/gov/ch/model/psc/PersonWithSignificantControlTest.java
+++ b/src/test/java/uk/gov/ch/model/psc/PersonWithSignificantControlTest.java
@@ -7,18 +7,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class PersonWithSignificantControlTest {
 
-    private static String HOUSE_NAME_NUMBER = "19";
-    private static String STREET = "My Street";
-    private static String CARE_OF = "care of";
-    private static String COUNTRY_NAME = "England";
-    private static String POST_TOWN = "London";
-    private static String PO_BOX = "PO box";
-    private static String POST_CODE = "LW1 1AA";
-    private static String REGION = "region";
+    private static final String HOUSE_NAME_NUMBER = "19";
+    private static final String STREET = "My Street";
+    private static final String CARE_OF = "care of";
+    private static final String COUNTRY_NAME = "England";
+    private static final String POST_TOWN = "London";
+    private static final String PO_BOX = "PO box";
+    private static final String POST_CODE = "LW1 1AA";
+    private static final String REGION = "region";
 
     @Test
     void testUraAddress() {
+        final String ADDRESS_LINE_1 = "should not get used";
+
         PersonWithSignificantControl psc = new PersonWithSignificantControl();
+        psc.setAddressLine1(ADDRESS_LINE_1);
         psc.setHouseNameNumber(HOUSE_NAME_NUMBER);
         psc.setStreet(STREET);
         psc.setCareOf(CARE_OF);

--- a/src/test/java/uk/gov/ch/model/psc/PersonWithSignificantControlTest.java
+++ b/src/test/java/uk/gov/ch/model/psc/PersonWithSignificantControlTest.java
@@ -1,0 +1,65 @@
+package uk.gov.ch.model.psc;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.api.model.common.Address;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PersonWithSignificantControlTest {
+
+    private static String HOUSE_NAME_NUMBER = "19";
+    private static String STREET = "My Street";
+    private static String CARE_OF = "care of";
+    private static String COUNTRY_NAME = "England";
+    private static String POST_TOWN = "London";
+    private static String PO_BOX = "PO box";
+    private static String POST_CODE = "LW1 1AA";
+    private static String REGION = "region";
+
+    @Test
+    void testUraAddress() {
+        PersonWithSignificantControl psc = new PersonWithSignificantControl();
+        psc.setHouseNameNumber(HOUSE_NAME_NUMBER);
+        psc.setStreet(STREET);
+        psc.setCareOf(CARE_OF);
+        psc.setCountryName(COUNTRY_NAME);
+        psc.setPostTown(POST_TOWN);
+        psc.setPoBox(PO_BOX);
+        psc.setPostCode(POST_CODE);
+        psc.setRegion(REGION);
+
+        Address ura = psc.getAddress();
+        assertEquals(HOUSE_NAME_NUMBER, ura.getAddressLine1());
+        assertEquals(STREET, ura.getAddressLine2());
+        assertEquals(CARE_OF, ura.getCareOf());
+        assertEquals(COUNTRY_NAME, ura.getCountry());
+        assertEquals(POST_TOWN, ura.getLocality());
+        assertEquals(PO_BOX, ura.getPoBox());
+        assertEquals(POST_CODE, ura.getPostalCode());
+        assertEquals(REGION, ura.getRegion());
+    }
+
+    @Test
+    void testServiceAddress() {
+        PersonWithSignificantControl psc = new PersonWithSignificantControl();
+        psc.setServiceAddressLine1(HOUSE_NAME_NUMBER);
+        psc.setServiceAddressLine2(STREET);
+        psc.setServiceAddressCareOf(CARE_OF);
+        psc.setServiceAddressCountryName(COUNTRY_NAME);
+        psc.setServiceAddressPostTown(POST_TOWN);
+        psc.setServiceAddressPoBox(PO_BOX);
+        psc.setServiceAddressPostCode(POST_CODE);
+        psc.setServiceAddressRegion(REGION);
+
+        Address serviceAddress = psc.getServiceAddress();
+
+        assertEquals(HOUSE_NAME_NUMBER, serviceAddress.getAddressLine1());
+        assertEquals(STREET, serviceAddress.getAddressLine2());
+        assertEquals(CARE_OF, serviceAddress.getCareOf());
+        assertEquals(COUNTRY_NAME, serviceAddress.getCountry());
+        assertEquals(POST_TOWN, serviceAddress.getLocality());
+        assertEquals(PO_BOX, serviceAddress.getPoBox());
+        assertEquals(POST_CODE, serviceAddress.getPostalCode());
+        assertEquals(REGION, serviceAddress.getRegion());
+    }
+}


### PR DESCRIPTION
…ine 1

Changing the PersonWithSignificantControl model class to capture the HOUSE_NAME_NUMBER field from Oracle query.
Then using HOUSE_NAME_NUMBER as the URA address line 1 field.