### PR TITLE
BI-10739 Ignore shareholders with zero shares

### DIFF
--- a/src/main/java/uk/gov/ch/repository/shareholder/ShareholderRepository.java
+++ b/src/main/java/uk/gov/ch/repository/shareholder/ShareholderRepository.java
@@ -20,11 +20,15 @@ public interface ShareholderRepository  extends PagingAndSortingRepository<Share
             + "JOIN corporate_body cb ON cb.CORPORATE_BODY_ID = shd.CORPORATE_BODY_ID "
             + "LEFT JOIN currency_type ctp ON shd.currency_type_id = ctp.currency_type_id "
             + "LEFT JOIN share_class_type sct on sct.SHARE_CLASS_TYPE_ID = shd.SHARE_CLASS_TYPE_ID "
-            + "WHERE cb.INCORPORATION_NUMBER =  ?1",
+            + "WHERE cb.INCORPORATION_NUMBER = ?1 "
+            + "AND shd.NUMBER_OF_SHARES > 0 "
+            + "AND shd.NUMBER_OF_SHARES IS NOT NULL ",
             countQuery = "select count(*) FROM shareholder sh, shareholding shd, corporate_body cb, currency_type ctp, share_class_type sct "
                     + "WHERE sh.SHAREHOLDING_ID = shd.SHAREHOLDING_ID "
                     + "AND cb.CORPORATE_BODY_ID = shd.CORPORATE_BODY_ID "
                     + "AND shd.currency_type_id = ctp.currency_type_id "
+                    + "AND shd.NUMBER_OF_SHARES > 0 "
+                    + "AND shd.NUMBER_OF_SHARES IS NOT NULL "
                     + "AND sct.SHARE_CLASS_TYPE_ID = shd.SHARE_CLASS_TYPE_ID "
                     + "AND cb.INCORPORATION_NUMBER = ?1",
             nativeQuery = true)
@@ -33,7 +37,10 @@ public interface ShareholderRepository  extends PagingAndSortingRepository<Share
     @Query(value = "SELECT COUNT(*) "
             + "FROM shareholder sh INNER JOIN shareholding shd ON sh.SHAREHOLDING_ID = shd.SHAREHOLDING_ID "
             + "JOIN corporate_body cb on cb.CORPORATE_BODY_ID = shd.CORPORATE_BODY_ID "
-            + "WHERE cb.INCORPORATION_NUMBER = ?", nativeQuery = true)
+            + "WHERE cb.INCORPORATION_NUMBER = ? "
+            + "AND shd.NUMBER_OF_SHARES > 0 "
+            + "AND shd.NUMBER_OF_SHARES IS NOT NULL"
+            , nativeQuery = true)
     int getShareholderCount(String incorporationNumber);
 
 }


### PR DESCRIPTION
* Changed for Confirmation Statement to ensure that Stop Screen no
longer shows if shareholders having zero shares cause the total
count to be greater than 1
* Shareholders with a NULL value for number of shares are also
excluded from the total
* Similarly, shareholder data is not returned when number of shares
is zero or NULL