### PR TITLE
BI-11924-Add debtor discharge date to search result object

### DIFF
--- a/src/main/java/uk/gov/ch/model/officer/bankrupt/ScottishBankruptOfficerSearchResult.java
+++ b/src/main/java/uk/gov/ch/model/officer/bankrupt/ScottishBankruptOfficerSearchResult.java
@@ -8,105 +8,115 @@ import java.time.LocalDate;
 @JsonInclude(Include.NON_NULL)
 public class ScottishBankruptOfficerSearchResult {
 
-        private String ephemeralKey;
-        private String forename1;
-        private String forename2;
-        private String surname;
-        private String addressLine1;
-        private String addressLine2;
-        private String addressLine3;
-        private String town;
-        private String county;
-        private String postcode;
-        private LocalDate dateOfBirth;
-
-        public String getEphemeralKey() {
-            return ephemeralKey;
-        }
-
-        public void setEphemeralKey(String ephemeralKey) {
-            this.ephemeralKey = ephemeralKey;
-        }
-
-        public String getForename1() {
-            return forename1;
-        }
-
-        public void setForename1(String forename1) {
-            this.forename1 = forename1;
-        }
+    private String ephemeralKey;
+    private String forename1;
+    private String forename2;
+    private String surname;
+    private String addressLine1;
+    private String addressLine2;
+    private String addressLine3;
+    private String town;
+    private String county;
+    private String postcode;
+    private LocalDate dateOfBirth;
+    private LocalDate debtorDischargeDate;
 
 
-
-        public String getForename2() {
-            return forename2;
-        }
-
-        public void setForename2(String forename2) {
-            this.forename2 = forename2;
-        }
-
-        public String getSurname() {
-            return surname;
-        }
-
-        public void setSurname(String surname) {
-            this.surname = surname;
-        }
-
-        public String getAddressLine1() {
-            return addressLine1;
-        }
-
-        public void setAddressLine1(String addressLine1) {
-            this.addressLine1 = addressLine1;
-        }
-
-        public String getAddressLine2() {
-            return addressLine2;
-        }
-
-        public void setAddressLine2(String addressLine2) {
-            this.addressLine2 = addressLine2;
-        }
-
-        public String getAddressLine3() {
-            return addressLine3;
-        }
-
-        public void setAddressLine3(String addressLine3) {
-            this.addressLine3 = addressLine3;
-        }
-
-        public String getTown() {
-            return town;
-        }
-
-        public void setTown(String town) {
-            this.town = town;
-        }
-
-        public String getCounty() {
-            return county;
-        }
-
-        public void setCounty(String county) {
-            this.county = county;
-        }
-
-        public String getPostcode() {
-            return postcode;
-        }
-
-        public void setPostcode(String postcode) {
-            this.postcode = postcode;
-        }
-
-        public LocalDate getDateOfBirth() {
-            return dateOfBirth;
-        }
-
-        public void setDateOfBirth(LocalDate dateOfBirth) {
-            this.dateOfBirth = dateOfBirth;
-        }
+    public String getEphemeralKey() {
+        return ephemeralKey;
     }
+
+    public void setEphemeralKey(String ephemeralKey) {
+        this.ephemeralKey = ephemeralKey;
+    }
+
+    public String getForename1() {
+        return forename1;
+    }
+
+    public void setForename1(String forename1) {
+        this.forename1 = forename1;
+    }
+
+
+
+    public String getForename2() {
+        return forename2;
+    }
+
+    public void setForename2(String forename2) {
+        this.forename2 = forename2;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+
+    public String getAddressLine1() {
+        return addressLine1;
+    }
+
+    public void setAddressLine1(String addressLine1) {
+        this.addressLine1 = addressLine1;
+    }
+
+    public String getAddressLine2() {
+        return addressLine2;
+    }
+
+    public void setAddressLine2(String addressLine2) {
+        this.addressLine2 = addressLine2;
+    }
+
+    public String getAddressLine3() {
+        return addressLine3;
+    }
+
+    public void setAddressLine3(String addressLine3) {
+        this.addressLine3 = addressLine3;
+    }
+
+    public String getTown() {
+        return town;
+    }
+
+    public void setTown(String town) {
+        this.town = town;
+    }
+
+    public String getCounty() {
+        return county;
+    }
+
+    public void setCounty(String county) {
+        this.county = county;
+    }
+
+    public String getPostcode() {
+        return postcode;
+    }
+
+    public void setPostcode(String postcode) {
+        this.postcode = postcode;
+    }
+
+    public LocalDate getDateOfBirth() {
+        return dateOfBirth;
+    }
+
+    public void setDateOfBirth(LocalDate dateOfBirth) {
+        this.dateOfBirth = dateOfBirth;
+    }
+
+    public LocalDate getDebtorDischargeDate() {
+        return debtorDischargeDate;
+    }
+
+    public void setDebtorDischargeDate(LocalDate debtorDischargeDate) {
+        this.debtorDischargeDate = debtorDischargeDate;
+    }
+}

--- a/src/main/java/uk/gov/ch/transformers/officer/bankrupt/BankruptOfficersTransformer.java
+++ b/src/main/java/uk/gov/ch/transformers/officer/bankrupt/BankruptOfficersTransformer.java
@@ -75,9 +75,9 @@ public class BankruptOfficersTransformer {
         details.setAddressLine1(scottishBankruptOfficerDetailsDataModel.getAddressLine1());
         details.setAddressLine2(scottishBankruptOfficerDetailsDataModel.getAddressLine2());
         details.setAddressLine3(scottishBankruptOfficerDetailsDataModel.getAddressLine3());
-        details.setDebtorDischargeDate(scottishBankruptOfficerDetailsDataModel.getDebtorDischargeDate());
         details.setCounty(scottishBankruptOfficerDetailsDataModel.getAddressCounty());
         details.setTown(scottishBankruptOfficerDetailsDataModel.getAddressTown());
+        details.setDebtorDischargeDate(scottishBankruptOfficerDetailsDataModel.getDebtorDischargeDate());
 
         return details;
     }

--- a/src/main/java/uk/gov/ch/transformers/officer/bankrupt/BankruptOfficersTransformer.java
+++ b/src/main/java/uk/gov/ch/transformers/officer/bankrupt/BankruptOfficersTransformer.java
@@ -75,6 +75,7 @@ public class BankruptOfficersTransformer {
         details.setAddressLine1(scottishBankruptOfficerDetailsDataModel.getAddressLine1());
         details.setAddressLine2(scottishBankruptOfficerDetailsDataModel.getAddressLine2());
         details.setAddressLine3(scottishBankruptOfficerDetailsDataModel.getAddressLine3());
+        details.setDebtorDischargeDate(scottishBankruptOfficerDetailsDataModel.getDebtorDischargeDate());
         details.setCounty(scottishBankruptOfficerDetailsDataModel.getAddressCounty());
         details.setTown(scottishBankruptOfficerDetailsDataModel.getAddressTown());
 

--- a/src/test/java/uk/gov/ch/transformers/officer/bankrupt/BankruptOfficersTransformerTest.java
+++ b/src/test/java/uk/gov/ch/transformers/officer/bankrupt/BankruptOfficersTransformerTest.java
@@ -18,7 +18,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
- class BankruptOfficersTransformerTest {
+class BankruptOfficersTransformerTest {
 
 
     private BankruptOfficersTransformer transformer;
@@ -67,6 +67,7 @@ import java.util.List;
         assertEquals(ADDRESS_COUNTY, convertedOfficer.getCounty());
         assertEquals(ADDRESS_POSTCODE, convertedOfficer.getPostcode());
         assertEquals(DATE_OF_BIRTH, convertedOfficer.getDateOfBirth());
+        assertEquals(DEBTOR_DISCHARGE, convertedOfficer.getDebtorDischargeDate());
 
     }
 
@@ -116,55 +117,55 @@ import java.util.List;
         assertEquals(5, convertedPage.getItemsPerPage());
     }
 
-     @Test
-     @DisplayName("Convert officer details with a null debtor discharge date")
-     void testConvertOfficerDetailsWithANullDebtorDischargeDate() {
-         ScottishBankruptOfficerDataModel newOfficer = createOfficer(null);
-         ScottishBankruptOfficerDetails convertedOfficer = transformer.convertToDetails(newOfficer);
-         assertEquals(EPHEMERAL_KEY, convertedOfficer.getEphemeralKey());
-         assertEquals(FORENAME1, convertedOfficer.getForename1());
-         assertEquals(FORENAME2, convertedOfficer.getForename2());
-         assertEquals(SURNAME, convertedOfficer.getSurname());
-         assertEquals(ADDRESS_LINE1, convertedOfficer.getAddressLine1());
-         assertEquals(ADDRESS_LINE2, convertedOfficer.getAddressLine2());
-         assertEquals(ADDRESS_LINE3, convertedOfficer.getAddressLine3());
-         assertEquals(ADDRESS_TOWN, convertedOfficer.getTown());
-         assertEquals(ADDRESS_COUNTY, convertedOfficer.getCounty());
-         assertEquals(ADDRESS_POSTCODE, convertedOfficer.getPostcode());
-         assertEquals(DATE_OF_BIRTH, convertedOfficer.getDateOfBirth());
-         assertEquals(ALIAS, convertedOfficer.getAlias());
-         assertEquals(CASE_REFERENCE, convertedOfficer.getCaseReference());
-         assertEquals(CASE_TYPE, convertedOfficer.getCaseType());
-         assertEquals(BANKRUPTCY_TYPE, convertedOfficer.getBankruptcyType());
-         assertEquals(START_DATE, convertedOfficer.getStartDate());
-         assertNull(convertedOfficer.getDebtorDischargeDate());
-         assertEquals(TRUSTEE_DISCHARGE_DATE, convertedOfficer.getTrusteeDischargeDate());
-     }
-     @Test
-     @DisplayName("Convert officer details with end of time debtor discharge date")
-     void testConvertOfficerDetailsWithEndOfTimeDebtorDischargeDate() {
-         ScottishBankruptOfficerDataModel newOfficer = createOfficer(DEBTOR_DISCHARGE_END_OF_TIME);
-         ScottishBankruptOfficerDetails convertedOfficer = transformer.convertToDetails(newOfficer);
-         assertEquals(EPHEMERAL_KEY, convertedOfficer.getEphemeralKey());
-         assertEquals(FORENAME1, convertedOfficer.getForename1());
-         assertEquals(FORENAME2, convertedOfficer.getForename2());
-         assertEquals(SURNAME, convertedOfficer.getSurname());
-         assertEquals(ADDRESS_LINE1, convertedOfficer.getAddressLine1());
-         assertEquals(ADDRESS_LINE2, convertedOfficer.getAddressLine2());
-         assertEquals(ADDRESS_LINE3, convertedOfficer.getAddressLine3());
-         assertEquals(ADDRESS_TOWN, convertedOfficer.getTown());
-         assertEquals(ADDRESS_COUNTY, convertedOfficer.getCounty());
-         assertEquals(ADDRESS_POSTCODE, convertedOfficer.getPostcode());
-         assertEquals(DATE_OF_BIRTH, convertedOfficer.getDateOfBirth());
-         assertEquals(ALIAS, convertedOfficer.getAlias());
-         assertEquals(CASE_REFERENCE, convertedOfficer.getCaseReference());
-         assertEquals(CASE_TYPE, convertedOfficer.getCaseType());
-         assertEquals(BANKRUPTCY_TYPE, convertedOfficer.getBankruptcyType());
-         assertEquals(START_DATE, convertedOfficer.getStartDate());
-         assertNull(convertedOfficer.getDebtorDischargeDate());
-         assertEquals(TRUSTEE_DISCHARGE_DATE, convertedOfficer.getTrusteeDischargeDate());
-     }
-    
+    @Test
+    @DisplayName("Convert officer details with a null debtor discharge date")
+    void testConvertOfficerDetailsWithANullDebtorDischargeDate() {
+        ScottishBankruptOfficerDataModel newOfficer = createOfficer(null);
+        ScottishBankruptOfficerDetails convertedOfficer = transformer.convertToDetails(newOfficer);
+        assertEquals(EPHEMERAL_KEY, convertedOfficer.getEphemeralKey());
+        assertEquals(FORENAME1, convertedOfficer.getForename1());
+        assertEquals(FORENAME2, convertedOfficer.getForename2());
+        assertEquals(SURNAME, convertedOfficer.getSurname());
+        assertEquals(ADDRESS_LINE1, convertedOfficer.getAddressLine1());
+        assertEquals(ADDRESS_LINE2, convertedOfficer.getAddressLine2());
+        assertEquals(ADDRESS_LINE3, convertedOfficer.getAddressLine3());
+        assertEquals(ADDRESS_TOWN, convertedOfficer.getTown());
+        assertEquals(ADDRESS_COUNTY, convertedOfficer.getCounty());
+        assertEquals(ADDRESS_POSTCODE, convertedOfficer.getPostcode());
+        assertEquals(DATE_OF_BIRTH, convertedOfficer.getDateOfBirth());
+        assertEquals(ALIAS, convertedOfficer.getAlias());
+        assertEquals(CASE_REFERENCE, convertedOfficer.getCaseReference());
+        assertEquals(CASE_TYPE, convertedOfficer.getCaseType());
+        assertEquals(BANKRUPTCY_TYPE, convertedOfficer.getBankruptcyType());
+        assertEquals(START_DATE, convertedOfficer.getStartDate());
+        assertNull(convertedOfficer.getDebtorDischargeDate());
+        assertEquals(TRUSTEE_DISCHARGE_DATE, convertedOfficer.getTrusteeDischargeDate());
+    }
+    @Test
+    @DisplayName("Convert officer details with end of time debtor discharge date")
+    void testConvertOfficerDetailsWithEndOfTimeDebtorDischargeDate() {
+        ScottishBankruptOfficerDataModel newOfficer = createOfficer(DEBTOR_DISCHARGE_END_OF_TIME);
+        ScottishBankruptOfficerDetails convertedOfficer = transformer.convertToDetails(newOfficer);
+        assertEquals(EPHEMERAL_KEY, convertedOfficer.getEphemeralKey());
+        assertEquals(FORENAME1, convertedOfficer.getForename1());
+        assertEquals(FORENAME2, convertedOfficer.getForename2());
+        assertEquals(SURNAME, convertedOfficer.getSurname());
+        assertEquals(ADDRESS_LINE1, convertedOfficer.getAddressLine1());
+        assertEquals(ADDRESS_LINE2, convertedOfficer.getAddressLine2());
+        assertEquals(ADDRESS_LINE3, convertedOfficer.getAddressLine3());
+        assertEquals(ADDRESS_TOWN, convertedOfficer.getTown());
+        assertEquals(ADDRESS_COUNTY, convertedOfficer.getCounty());
+        assertEquals(ADDRESS_POSTCODE, convertedOfficer.getPostcode());
+        assertEquals(DATE_OF_BIRTH, convertedOfficer.getDateOfBirth());
+        assertEquals(ALIAS, convertedOfficer.getAlias());
+        assertEquals(CASE_REFERENCE, convertedOfficer.getCaseReference());
+        assertEquals(CASE_TYPE, convertedOfficer.getCaseType());
+        assertEquals(BANKRUPTCY_TYPE, convertedOfficer.getBankruptcyType());
+        assertEquals(START_DATE, convertedOfficer.getStartDate());
+        assertNull(convertedOfficer.getDebtorDischargeDate());
+        assertEquals(TRUSTEE_DISCHARGE_DATE, convertedOfficer.getTrusteeDischargeDate());
+    }
+
 
     private ScottishBankruptOfficerDataModel createOfficer(LocalDate debtorDischargeDate) {
 


### PR DESCRIPTION
Resolves: [BI-11924](https://companieshouse.atlassian.net/browse/BI-11924)

Adding Debtor discharge date field to the search result entity objects so that debtor discharge date appears as a field in the results when `BankruptOfficers` is called. 