### PR TITLE
BI-6427-add in dob range search changes for ScottishBankrupt Officers

### DIFF
--- a/src/main/java/uk/gov/ch/model/officer/bankrupt/ScottishBankruptOfficerSearchFilters.java
+++ b/src/main/java/uk/gov/ch/model/officer/bankrupt/ScottishBankruptOfficerSearchFilters.java
@@ -10,7 +10,8 @@ public class ScottishBankruptOfficerSearchFilters {
 
     private String forename1;
     private String surname;
-    private String dateOfBirth;
+    private String fromDateOfBirth;
+    private String toDateOfBirth;
     private String postcode;
 
 
@@ -30,12 +31,20 @@ public class ScottishBankruptOfficerSearchFilters {
         this.surname = surname;
     }
 
-    public String getDateOfBirth() {
-        return dateOfBirth;
+    public String getFromDateOfBirth() {
+        return fromDateOfBirth;
     }
 
-    public void setDateOfBirth(String dateOfBirth) {
-        this.dateOfBirth = dateOfBirth;
+    public void setFromDateOfBirth(String fromDateOfBirth) {
+        this.fromDateOfBirth = fromDateOfBirth;
+    }
+
+    public String getToDateOfBirth() {
+        return toDateOfBirth;
+    }
+
+    public void setToDateOfBirth(String toDateOfBirth) {
+        this.toDateOfBirth = toDateOfBirth;
     }
 
     public String getPostcode() {
@@ -46,3 +55,4 @@ public class ScottishBankruptOfficerSearchFilters {
         this.postcode = postcode;
     }
 }
+

--- a/src/main/java/uk/gov/ch/repository/officers/ScottishBankruptOfficersRepository.java
+++ b/src/main/java/uk/gov/ch/repository/officers/ScottishBankruptOfficersRepository.java
@@ -33,15 +33,19 @@ public interface ScottishBankruptOfficersRepository extends PagingAndSortingRepo
                  + "from SCOTTISH_BANKRUPT_OFFICER "
                  + "where (:forename is null or upper(FORENAME_1) = upper(:forename)) "
                  + "and (:surname is null or upper(SURNAME) = upper(:surname)) "
-                 + "and (:dob is null or DATE_OF_BIRTH = TO_DATE(:dob, 'YYYY-MM-DD')) "
+                 + "and ((:fromDob is null and :toDob is null) "
+                 + "or (DATE_OF_BIRTH = TO_DATE(:fromDob, 'YYYY-MM-DD')) " + "or (DATE_OF_BIRTH = TO_DATE(:toDob, 'YYYY-MM-DD'))"
+                 + "or (DATE_OF_BIRTH between TO_DATE(:fromDob, 'YYYY-MM-DD') and TO_DATE(:toDob, 'YYYY-MM-DD')))"
                  + "and (:postcode is null or upper(replace(ADDRESS_POSTCODE, ' ', '')) = upper(replace(:postcode, ' ', ''))) "
                  + "order by START_DATE desc",
            countQuery = "select COUNT(*) "
                    + "from SCOTTISH_BANKRUPT_OFFICER "
                    + "where (:forename is null or upper(FORENAME_1) = upper(:forename)) "
                    + "and (:surname is null or upper(SURNAME) = upper(:surname)) "
-                   + "and (:dob is null or DATE_OF_BIRTH = TO_DATE(:dob, 'YYYY-MM-DD')) "
+                   + "and ((:fromDob is null and :toDob is null) "
+                   + "or (DATE_OF_BIRTH = TO_DATE(:fromDob, 'YYYY-MM-DD')) " + "or (DATE_OF_BIRTH = TO_DATE(:toDob, 'YYYY-MM-DD'))"
+                   + "or (DATE_OF_BIRTH between TO_DATE(:fromDob, 'YYYY-MM-DD') and TO_DATE(:toDob, 'YYYY-MM-DD')))"
                    + "and (:postcode is null or upper(replace(ADDRESS_POSTCODE, ' ', '')) = upper(replace(:postcode, ' ', ''))) ",
            nativeQuery = true)
-    Page<ScottishBankruptOfficerDataModel> findScottishBankruptOfficers(@Param("forename") String forename, @Param("surname") String surname, @Param("dob") String dob, @Param("postcode") String postcode, Pageable pageable);
+    Page<ScottishBankruptOfficerDataModel> findScottishBankruptOfficers(@Param("forename") String forename, @Param("surname") String surname, @Param("fromDob") String fromDateOfBirth, @Param("toDob") String toDateOfBirth, @Param("postcode") String postcode, Pageable pageable);
 }

--- a/src/main/java/uk/gov/ch/service/officer/bankrupt/impl/ScottishBankruptOfficerServiceImpl.java
+++ b/src/main/java/uk/gov/ch/service/officer/bankrupt/impl/ScottishBankruptOfficerServiceImpl.java
@@ -33,7 +33,8 @@ public class ScottishBankruptOfficerServiceImpl implements BankruptOfficerServic
 
         ScottishBankruptOfficerSearchFilters filters = search.getFilters();
         Page<ScottishBankruptOfficerDataModel> dataModel = scottishBankruptOfficersRepository.findScottishBankruptOfficers(
-            filters.getForename1(), filters.getSurname(), filters.getDateOfBirth(), filters.getPostcode(), page);
+            filters.getForename1(), filters.getSurname(), filters.getFromDateOfBirth(), filters.getToDateOfBirth(),
+                filters.getPostcode(), page);
 
         return bankruptOfficersTransformer.convertToSearchResults(dataModel);
     }

--- a/src/test/java/uk/gov/ch/service/officer/bankrupt/ScottishBankruptOfficerServiceImplTest.java
+++ b/src/test/java/uk/gov/ch/service/officer/bankrupt/ScottishBankruptOfficerServiceImplTest.java
@@ -47,14 +47,15 @@ import java.util.Optional;
     private static final int ITEMS_PER_PAGE = 2;
     private static final String FORENAME = "forename";
     private static final String SURNAME = "surname";
-    private static final String DATE_OF_BIRTH = "2020-01-01";
+    private static final String FROM_DATE_OF_BIRTH = "2020-01-01";
+    private static final String TO_DATE_OF_BIRTH = "2020-02-01";
     private static final String POSTCODE = "postcode";
     private static final String EPHEMERAL_KEY = "0123456";
 
     @Test
     @DisplayName("Search for bankrupt officers")
     void testScottishBankruptSearch() {
-        when(repo.findScottishBankruptOfficers(eq(FORENAME), eq(SURNAME), eq(DATE_OF_BIRTH), eq(POSTCODE), any(Pageable.class))).thenReturn(page);
+        when(repo.findScottishBankruptOfficers(eq(FORENAME), eq(SURNAME), eq(FROM_DATE_OF_BIRTH), eq(TO_DATE_OF_BIRTH), eq(POSTCODE), any(Pageable.class))).thenReturn(page);
 
         ScottishBankruptOfficerSearchResults expectedResults = new ScottishBankruptOfficerSearchResults();
         when(transformer.convertToSearchResults(page)).thenReturn(expectedResults);
@@ -62,7 +63,8 @@ import java.util.Optional;
         ScottishBankruptOfficerSearchFilters filters = new ScottishBankruptOfficerSearchFilters();
         filters.setForename1(FORENAME);
         filters.setSurname(SURNAME);
-        filters.setDateOfBirth(DATE_OF_BIRTH);
+        filters.setFromDateOfBirth(FROM_DATE_OF_BIRTH);
+        filters.setToDateOfBirth(TO_DATE_OF_BIRTH);
         filters.setPostcode(POSTCODE);
 
         ScottishBankruptOfficerSearch search = new ScottishBankruptOfficerSearch();
@@ -74,7 +76,7 @@ import java.util.Optional;
         assertEquals(expectedResults, results);
 
         ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
-        verify(repo).findScottishBankruptOfficers(eq(FORENAME), eq(SURNAME), eq(DATE_OF_BIRTH), eq(POSTCODE), captor.capture());
+        verify(repo).findScottishBankruptOfficers(eq(FORENAME), eq(SURNAME), eq(FROM_DATE_OF_BIRTH), eq(TO_DATE_OF_BIRTH), eq(POSTCODE), captor.capture());
         Pageable pageable = captor.getValue();
         assertEquals(START_INDEX, pageable.getPageNumber());
         assertEquals(ITEMS_PER_PAGE, pageable.getPageSize());


### PR DESCRIPTION
Resolves: [BI-6427](https://companieshouse.atlassian.net/browse/BI-6427)

- Add in SQL changes to be able to search officers with DOB in range of the fromDOB and toDob filters.
- Amend unit tests to support new filters

