### PR TITLE
BI-11967-Debtor Discharge Date to be blank if the officer does not have a discharge date

### DIFF
--- a/src/main/java/uk/gov/ch/transformers/officer/bankrupt/BankruptOfficersTransformer.java
+++ b/src/main/java/uk/gov/ch/transformers/officer/bankrupt/BankruptOfficersTransformer.java
@@ -77,7 +77,12 @@ public class BankruptOfficersTransformer {
         details.setAddressLine3(scottishBankruptOfficerDetailsDataModel.getAddressLine3());
         details.setCounty(scottishBankruptOfficerDetailsDataModel.getAddressCounty());
         details.setTown(scottishBankruptOfficerDetailsDataModel.getAddressTown());
-        details.setDebtorDischargeDate(scottishBankruptOfficerDetailsDataModel.getDebtorDischargeDate());
+
+        LocalDate debtorDischargeDate = scottishBankruptOfficerDetailsDataModel.getDebtorDischargeDate();
+
+        if (debtorDischargeDate != null && !END_OF_TIME.isEqual(debtorDischargeDate)) {
+            details.setDebtorDischargeDate(debtorDischargeDate);
+        }
 
         return details;
     }

--- a/src/test/java/uk/gov/ch/transformers/officer/bankrupt/BankruptOfficersTransformerTest.java
+++ b/src/test/java/uk/gov/ch/transformers/officer/bankrupt/BankruptOfficersTransformerTest.java
@@ -71,6 +71,54 @@ class BankruptOfficersTransformerTest {
 
     }
 
+
+
+    @Test
+    @DisplayName("Convert search results with end of time debtor discharge date")
+    void testConvertSearchResultsWithEndOfTimeDebtorDischargeDate() {
+        ScottishBankruptOfficerDataModel newOfficer = createOfficer(DEBTOR_DISCHARGE_END_OF_TIME);
+        ScottishBankruptOfficerSearchResult convertedOfficer = transformer.convertToSearchResult(newOfficer);
+
+        assertEquals(EPHEMERAL_KEY, convertedOfficer.getEphemeralKey());
+        assertEquals(FORENAME1, convertedOfficer.getForename1());
+        assertEquals(FORENAME2, convertedOfficer.getForename2());
+        assertEquals(SURNAME, convertedOfficer.getSurname());
+        assertEquals(ADDRESS_LINE1, convertedOfficer.getAddressLine1());
+        assertEquals(ADDRESS_LINE2, convertedOfficer.getAddressLine2());
+        assertEquals(ADDRESS_LINE3, convertedOfficer.getAddressLine3());
+        assertEquals(ADDRESS_TOWN, convertedOfficer.getTown());
+        assertEquals(ADDRESS_COUNTY, convertedOfficer.getCounty());
+        assertEquals(ADDRESS_POSTCODE, convertedOfficer.getPostcode());
+        assertEquals(DATE_OF_BIRTH, convertedOfficer.getDateOfBirth());
+        assertNull(convertedOfficer.getDebtorDischargeDate());
+
+    }
+
+
+    @Test
+    @DisplayName("Convert search results with null debtor discharge date")
+    void testConvertSearchResultsWithNullDebtorDischargeDate() {
+        ScottishBankruptOfficerDataModel newOfficer = createOfficer(null);
+        ScottishBankruptOfficerSearchResult convertedOfficer = transformer.convertToSearchResult(newOfficer);
+
+        assertEquals(EPHEMERAL_KEY, convertedOfficer.getEphemeralKey());
+        assertEquals(FORENAME1, convertedOfficer.getForename1());
+        assertEquals(FORENAME2, convertedOfficer.getForename2());
+        assertEquals(SURNAME, convertedOfficer.getSurname());
+        assertEquals(ADDRESS_LINE1, convertedOfficer.getAddressLine1());
+        assertEquals(ADDRESS_LINE2, convertedOfficer.getAddressLine2());
+        assertEquals(ADDRESS_LINE3, convertedOfficer.getAddressLine3());
+        assertEquals(ADDRESS_TOWN, convertedOfficer.getTown());
+        assertEquals(ADDRESS_COUNTY, convertedOfficer.getCounty());
+        assertEquals(ADDRESS_POSTCODE, convertedOfficer.getPostcode());
+        assertEquals(DATE_OF_BIRTH, convertedOfficer.getDateOfBirth());
+        assertNull(convertedOfficer.getDebtorDischargeDate());
+
+    }
+
+
+
+
     @Test
     @DisplayName("Convert officer details")
     void testConvertOfficerDetails() {
@@ -165,6 +213,8 @@ class BankruptOfficersTransformerTest {
         assertNull(convertedOfficer.getDebtorDischargeDate());
         assertEquals(TRUSTEE_DISCHARGE_DATE, convertedOfficer.getTrusteeDischargeDate());
     }
+
+
 
 
     private ScottishBankruptOfficerDataModel createOfficer(LocalDate debtorDischargeDate) {


### PR DESCRIPTION
Resolves: [BI-11967](https://companieshouse.atlassian.net/browse/BI-11967)

- Adding if statement in `BankruptOfficersTransformer` class  to check that officers with no debtor discharge date will not have the date set and thus have a blank row instead in search results. This is to replace current behaviour where officers with no debtor discharge date are shown to have this set to an end-of-time date in search results. 