### PR TITLE
Feature/BI-12027 add case type to BADOS scotland results page

### DIFF
--- a/src/main/java/uk/gov/ch/model/officer/bankrupt/ScottishBankruptOfficerSearchResult.java
+++ b/src/main/java/uk/gov/ch/model/officer/bankrupt/ScottishBankruptOfficerSearchResult.java
@@ -20,6 +20,7 @@ public class ScottishBankruptOfficerSearchResult {
     private String postcode;
     private LocalDate dateOfBirth;
     private LocalDate debtorDischargeDate;
+    private String CaseType;
 
 
     public String getEphemeralKey() {
@@ -118,5 +119,13 @@ public class ScottishBankruptOfficerSearchResult {
 
     public void setDebtorDischargeDate(LocalDate debtorDischargeDate) {
         this.debtorDischargeDate = debtorDischargeDate;
+    }
+
+    public String getCaseType() {
+        return CaseType;
+    }
+
+    public void setCaseType(String caseType) {
+        CaseType = caseType;
     }
 }

--- a/src/main/java/uk/gov/ch/transformers/officer/bankrupt/BankruptOfficersTransformer.java
+++ b/src/main/java/uk/gov/ch/transformers/officer/bankrupt/BankruptOfficersTransformer.java
@@ -77,6 +77,7 @@ public class BankruptOfficersTransformer {
         details.setAddressLine3(scottishBankruptOfficerDetailsDataModel.getAddressLine3());
         details.setCounty(scottishBankruptOfficerDetailsDataModel.getAddressCounty());
         details.setTown(scottishBankruptOfficerDetailsDataModel.getAddressTown());
+        details.setCaseType(scottishBankruptOfficerDetailsDataModel.getCaseType());
 
         LocalDate debtorDischargeDate = scottishBankruptOfficerDetailsDataModel.getDebtorDischargeDate();
 

--- a/src/test/java/uk/gov/ch/transformers/officer/bankrupt/BankruptOfficersTransformerTest.java
+++ b/src/test/java/uk/gov/ch/transformers/officer/bankrupt/BankruptOfficersTransformerTest.java
@@ -68,6 +68,7 @@ class BankruptOfficersTransformerTest {
         assertEquals(ADDRESS_POSTCODE, convertedOfficer.getPostcode());
         assertEquals(DATE_OF_BIRTH, convertedOfficer.getDateOfBirth());
         assertEquals(DEBTOR_DISCHARGE, convertedOfficer.getDebtorDischargeDate());
+        assertEquals(CASE_TYPE, convertedOfficer.getCaseType());
 
     }
 
@@ -91,6 +92,7 @@ class BankruptOfficersTransformerTest {
         assertEquals(ADDRESS_POSTCODE, convertedOfficer.getPostcode());
         assertEquals(DATE_OF_BIRTH, convertedOfficer.getDateOfBirth());
         assertNull(convertedOfficer.getDebtorDischargeDate());
+        assertEquals(CASE_TYPE, convertedOfficer.getCaseType());
 
     }
 
@@ -113,7 +115,7 @@ class BankruptOfficersTransformerTest {
         assertEquals(ADDRESS_POSTCODE, convertedOfficer.getPostcode());
         assertEquals(DATE_OF_BIRTH, convertedOfficer.getDateOfBirth());
         assertNull(convertedOfficer.getDebtorDischargeDate());
-
+        assertEquals(CASE_TYPE, convertedOfficer.getCaseType());
     }
 
 


### PR DESCRIPTION
Resolves [BI-12027](https://companieshouse.atlassian.net/browse/BI-12027)

Scottish Bankrupt Officer changes -Move casetype field to search results entity classes and transformer so that field can be displayed in BADOS officer search result page
