### PR TITLE
SUP-1115 - allow override of DB pool size by env var

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,7 @@ spring.datasource.url=${CHIPS_DATASOURCE_URL}
 spring.datasource.username=${CHIPS_DATASOURCE_USERNAME}
 spring.datasource.password=${CHIPS_DATASOURCE_PASSWORD}
 spring.datasource.driver.class=oracle.jdbc.driver.OracleDriver
+spring.datasource.hikari.maximum-pool-size=${CHIPS_DATASOURCE_MAX_POOL_SIZE:10}
 
 spring.jpa.hibernate.ddl-auto=none
 spring.jps.database-platform=org.hibernate.dialect.OracleDialect


### PR DESCRIPTION
Allow override of the DB connection pool size by setting the env var `CHIPS_DATASOURCE_MAX_POOL_SIZE`.  If there is no env var set, the default size of 10 will continue to be used.

This allows an increase/decrease without the need for a rebuild of the oracle-query-api.

Resolves:
https://companieshouse.atlassian.net/browse/SUP-1115