### PR TITLE
ASM-2318 Override vulnerable versions brought in by dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,18 @@
               <artifactId>tomcat-embed-el</artifactId>
               <version>${tomcat-embed.version}</version>
           </dependency>
+          <!-- structured-logging 3.0.57 brings in jackson-databind 2.21.4 which has CVE-2026-54515 -->
+          <dependency>
+              <groupId>com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-databind</artifactId>
+              <version>2.22.1</version>
+          </dependency>
+          <!-- spring-boot 4.1.0 brings in logback-classic 1.5.34 which has CVE-2026-10532 -->
+          <dependency>
+              <groupId>ch.qos.logback</groupId>
+              <artifactId>logback-classic</artifactId>
+              <version>1.5.37</version>
+          </dependency>
       </dependencies>
 
     </dependencyManagement>


### PR DESCRIPTION
## Jira ticket:
[ASM-2318](https://companieshouse.atlassian.net/browse/ASM-2318)
## Change summary
Override vulnerable versions brought in by dependencies:
- structured-logging 3.0.57 brings in jackson-databind 2.21.4 which has CVE-2026-54515
- spring-boot 4.1.0 brings in logback-classic 1.5.34 which has CVE-2026-10532
## Checklist
When creating your PR, please ensure to:
- [ ] Follow our [coding standard guidelines](https://github.com/companieshouse/styleguides)
- [ ] Update your change with unit and integration tests - Sonar expects code coverage >= 80%
- [ ] Test your changes locally e.g. in Docker for a dependent service
- [ ] Ensure 'README'/Configs/Logging etc. are up to date
- [ ] Request a code owner review

[ASM-2318]: https://companieshouse.atlassian.net/browse/ASM-2318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ